### PR TITLE
Preserve Image Item scale on clone

### DIFF
--- a/kadas/gui/mapitems/kadasmapitem.cpp
+++ b/kadas/gui/mapitems/kadasmapitem.cpp
@@ -47,12 +47,12 @@ KadasMapItem::~KadasMapItem()
 KadasMapItem *KadasMapItem::clone() const
 {
   KadasMapItem *item = _clone();
-  item->setState( constState()->clone() );
   for ( int i = 0, n = metaObject()->propertyCount(); i < n; ++i )
   {
     QMetaProperty prop = metaObject()->property( i );
     prop.write( item, prop.read( this ) );
   }
+  item->setState( constState()->clone() );
   return item;
 }
 


### PR DESCRIPTION
Some map items property set methods can modify the state, so clone it at last