### PR TITLE
Properly initialize registry

### DIFF
--- a/kadas/gui/mapitemeditors/kadasgpxrouteeditor.cpp
+++ b/kadas/gui/mapitemeditors/kadasgpxrouteeditor.cpp
@@ -20,9 +20,6 @@
 #include <kadas/gui/mapitems/kadasgpxrouteitem.h>
 #include <kadas/gui/mapitemeditors/kadasgpxrouteeditor.h>
 
-
-KADAS_REGISTER_MAP_ITEM_EDITOR( KadasGpxRouteEditor, []( KadasMapItem *item, KadasMapItemEditor::EditorType ) { return new KadasGpxRouteEditor( item ); } )
-
 KadasGpxRouteEditor::KadasGpxRouteEditor( KadasMapItem *item )
   : KadasMapItemEditor( item )
 {

--- a/kadas/gui/mapitemeditors/kadasgpxwaypointeditor.cpp
+++ b/kadas/gui/mapitemeditors/kadasgpxwaypointeditor.cpp
@@ -20,9 +20,6 @@
 #include <kadas/gui/mapitems/kadasgpxwaypointitem.h>
 #include <kadas/gui/mapitemeditors/kadasgpxwaypointeditor.h>
 
-
-KADAS_REGISTER_MAP_ITEM_EDITOR( KadasGpxWaypointEditor, []( KadasMapItem *item, KadasMapItemEditor::EditorType ) { return new KadasGpxWaypointEditor( item ); } )
-
 KadasGpxWaypointEditor::KadasGpxWaypointEditor( KadasMapItem *item )
   : KadasMapItemEditor( item )
 {

--- a/kadas/gui/mapitemeditors/kadasmapitemeditor.cpp
+++ b/kadas/gui/mapitemeditors/kadasmapitemeditor.cpp
@@ -15,6 +15,7 @@
  ***************************************************************************/
 
 #include <thread>
+#include <mutex>
 
 #include <kadas/gui/mapitemeditors/kadasmapitemeditor.h>
 #include "kadas/gui/mapitemeditors/kadasgpxrouteeditor.h"

--- a/kadas/gui/mapitemeditors/kadasmapitemeditor.cpp
+++ b/kadas/gui/mapitemeditors/kadasmapitemeditor.cpp
@@ -14,6 +14,8 @@
  *                                                                         *
  ***************************************************************************/
 
+#include <thread>
+
 #include <kadas/gui/mapitemeditors/kadasmapitemeditor.h>
 #include "kadas/gui/mapitemeditors/kadasgpxrouteeditor.h"
 #include "kadas/gui/mapitemeditors/kadasgpxwaypointeditor.h"

--- a/kadas/gui/mapitemeditors/kadasmapitemeditor.cpp
+++ b/kadas/gui/mapitemeditors/kadasmapitemeditor.cpp
@@ -15,9 +15,24 @@
  ***************************************************************************/
 
 #include <kadas/gui/mapitemeditors/kadasmapitemeditor.h>
+#include "kadas/gui/mapitemeditors/kadasgpxrouteeditor.h"
+#include "kadas/gui/mapitemeditors/kadasgpxwaypointeditor.h"
+#include "kadas/gui/mapitemeditors/kadasredliningtexteditor.h"
+#include "kadas/gui/mapitemeditors/kadassymbolattributeseditor.h"
+#include "kadas/gui/maptools/kadasmaptoolmeasure.h"
+
+Q_GLOBAL_STATIC(KadasMapItemEditor::Registry, sRegistry)
+
+std::once_flag onceFlag;
 
 KadasMapItemEditor::Registry *KadasMapItemEditor::registry()
 {
-  static Registry instance;
-  return &instance;
+  std::call_once( onceFlag, [] (){
+    sRegistry->insert( QStringLiteral( "KadasGpxRouteEditor" ), [] ( KadasMapItem* item, KadasMapItemEditor::EditorType ) { return new KadasGpxRouteEditor( item ); } );
+    sRegistry->insert( QStringLiteral( "KadasSymbolAttributesEditor" ), [] ( KadasMapItem* item, KadasMapItemEditor::EditorType ) { return new KadasSymbolAttributesEditor( item ); } );
+    sRegistry->insert( QStringLiteral( "KadasGpxWaypointEditor" ), [] ( KadasMapItem* item, KadasMapItemEditor::EditorType ) { return new KadasGpxWaypointEditor( item ); } );
+    sRegistry->insert( QStringLiteral( "KadasRedliningTextEditor" ), [] ( KadasMapItem* item, KadasMapItemEditor::EditorType ) { return new KadasRedliningTextEditor( item ); } );
+    sRegistry->insert( QStringLiteral( "KadasMeasureWidget" ), [] ( KadasMapItem* item, KadasMapItemEditor::EditorType ) { return new KadasMeasureWidget( item ); } );
+  });
+  return sRegistry;
 };

--- a/kadas/gui/mapitemeditors/kadasmapitemeditor.h
+++ b/kadas/gui/mapitemeditors/kadasmapitemeditor.h
@@ -59,10 +59,4 @@ class KADAS_GUI_EXPORT KadasMapItemEditor : public QWidget
     KadasMapItem *mItem;
 };
 
-#ifndef SIP_RUN
-#define KADAS_REGISTER_MAP_ITEM_EDITOR(classname, factory) \
-  static int register##classname(){ KadasMapItemEditor::registry()->insert(#classname, factory); return 0; } \
-  static int __reg##classname = register##classname();
-#endif
-
 #endif // KADASMAPITEMEDITOR_H

--- a/kadas/gui/mapitemeditors/kadasredliningitemeditor.cpp
+++ b/kadas/gui/mapitemeditors/kadasredliningitemeditor.cpp
@@ -21,8 +21,6 @@
 #include <kadas/gui/mapitemeditors/kadasredliningitemeditor.h>
 
 
-KADAS_REGISTER_MAP_ITEM_EDITOR( KadasRedliningItemEditor, []( KadasMapItem *item, KadasMapItemEditor::EditorType ) { return new KadasRedliningItemEditor( item ); } )
-
 KadasRedliningItemEditor::KadasRedliningItemEditor( KadasMapItem *item )
   : KadasMapItemEditor( item )
 {

--- a/kadas/gui/mapitemeditors/kadasredliningtexteditor.cpp
+++ b/kadas/gui/mapitemeditors/kadasredliningtexteditor.cpp
@@ -21,7 +21,7 @@
 #include <kadas/gui/mapitemeditors/kadasredliningtexteditor.h>
 
 
-KADAS_REGISTER_MAP_ITEM_EDITOR( KadasRedliningTextEditor, []( KadasMapItem *item, KadasMapItemEditor::EditorType ) { return new KadasRedliningTextEditor( item ); } )
+
 
 KadasRedliningTextEditor::KadasRedliningTextEditor( KadasMapItem *item )
   : KadasMapItemEditor( item )

--- a/kadas/gui/mapitemeditors/kadassymbolattributeseditor.cpp
+++ b/kadas/gui/mapitemeditors/kadassymbolattributeseditor.cpp
@@ -21,10 +21,6 @@
 #include <kadas/gui/kadasrichtexteditor.h>
 #include <kadas/gui/mapitems/kadassymbolitem.h>
 #include <kadas/gui/mapitemeditors/kadassymbolattributeseditor.h>
-
-
-KADAS_REGISTER_MAP_ITEM_EDITOR( KadasSymbolAttributesEditor, []( KadasMapItem *item, KadasMapItemEditor::EditorType ) { return new KadasSymbolAttributesEditor( item ); } )
-
 KadasSymbolAttributesEditor::KadasSymbolAttributesEditor( KadasMapItem *item )
   : KadasMapItemEditor( item )
 {

--- a/kadas/gui/maptools/kadasmaptoolcreateitem.cpp
+++ b/kadas/gui/maptools/kadasmaptoolcreateitem.cpp
@@ -84,7 +84,9 @@ void KadasMapToolCreateItem::activate()
     connect( layerSelection, &KadasLayerSelectionWidget::selectedLayerChanged, this, &KadasMapToolCreateItem::setTargetLayer );
     mBottomBar->layout()->addWidget( layerSelection );
   }
-  KadasMapItemEditor::Factory factory = KadasMapItemEditor::registry()->value( mItem->editor() );
+
+  auto registry = KadasMapItemEditor::registry();
+  KadasMapItemEditor::Factory factory = registry->value(mItem->editor());
   if ( factory )
   {
     mEditor = factory( mItem, KadasMapItemEditor::EditorType::CreateItemEditor );

--- a/kadas/gui/maptools/kadasmaptoolcreateitem.cpp
+++ b/kadas/gui/maptools/kadasmaptoolcreateitem.cpp
@@ -84,9 +84,7 @@ void KadasMapToolCreateItem::activate()
     connect( layerSelection, &KadasLayerSelectionWidget::selectedLayerChanged, this, &KadasMapToolCreateItem::setTargetLayer );
     mBottomBar->layout()->addWidget( layerSelection );
   }
-
-  auto registry = KadasMapItemEditor::registry();
-  KadasMapItemEditor::Factory factory = registry->value(mItem->editor());
+  KadasMapItemEditor::Factory factory = KadasMapItemEditor::registry()->value( mItem->editor() );
   if ( factory )
   {
     mEditor = factory( mItem, KadasMapItemEditor::EditorType::CreateItemEditor );

--- a/kadas/gui/maptools/kadasmaptoolmeasure.cpp
+++ b/kadas/gui/maptools/kadasmaptoolmeasure.cpp
@@ -32,9 +32,6 @@
 #include <kadas/gui/mapitems/kadascircleitem.h>
 #include <kadas/gui/maptools/kadasmaptoolmeasure.h>
 
-
-KADAS_REGISTER_MAP_ITEM_EDITOR( KadasMeasureWidget, []( KadasMapItem *item, KadasMapItemEditor::EditorType ) { return new KadasMeasureWidget( item ); } )
-
 KadasMeasureWidget::KadasMeasureWidget( KadasMapItem *item )
   : KadasMapItemEditor( item )
 {


### PR DESCRIPTION
The rich text editor for pins is usable again.

![image (1)](https://github.com/kadas-albireo/kadas-albireo2/assets/588407/e39bee89-7f23-4810-b73b-a4e4605e43ef)

The previous approach to register editors was depending on specific behavior of some compilers and not compatible with MSVC.

See https://stackoverflow.com/questions/3104923/static-initialization
