### PR TITLE
Add definition protected=public for bindings

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -34,6 +34,8 @@ endmacro(PY_COMPILE)
 
 separate_arguments(PYQT5_SIP_FLAGS_args UNIX_COMMAND "${PYQT5_SIP_FLAGS}")
 
+add_definitions(-Dprotected=public)
+
 # core module
 FILE(GLOB_RECURSE sip_files_core kadascore/*.sip kadascore/*.sip.in)
 SET(SIP_EXTRA_FILES_DEPEND ${sip_files_core})


### PR DESCRIPTION
I still need this definition to be able to build. Can we re-add it? Or there is another fix?

```
/home/domi/dev/kadas/build/python/kadasanalysis/build/_kadasanalysis/sip_kadasanalysispart5.cpp: In function ‘PyObject* meth_KadasNineCellFilter_calcFirstDerY(PyObject*, PyObject*, PyObject*)’:
/home/domi/dev/kadas/build/python/kadasanalysis/build/_kadasanalysis/sip_kadasanalysispart5.cpp:833:43: error: ‘float KadasNineCellFilter::calcFirstDerY(float*, float*, float*, float*, float*, float*, float*, float*, float*)’ is protected within this context
  833 |             sipRes = sipCpp->calcFirstDerY(&a0, &a1, &a2, &a3, &a4, &a5, &a6, &a7, &a8);
      |                      ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```