### PR TITLE
Browser menu remove transparency and bigger buttons

### DIFF
--- a/kadas/app/ui/kadaswindowbase.ui
+++ b/kadas/app/ui/kadaswindowbase.ui
@@ -42,7 +42,7 @@
        </sizepolicy>
       </property>
       <property name="frameShape">
-       <enum>QFrame::NoFrame</enum>
+       <enum>QFrame::Shape::NoFrame</enum>
       </property>
       <property name="lineWidth">
        <number>0</number>
@@ -105,7 +105,7 @@
          <number>0</number>
         </property>
         <property name="sizeConstraint">
-         <enum>QLayout::SetFixedSize</enum>
+         <enum>QLayout::SizeConstraint::SetFixedSize</enum>
         </property>
         <property name="leftMargin">
          <number>0</number>
@@ -187,10 +187,10 @@
            </size>
           </property>
           <property name="frameShape">
-           <enum>QFrame::StyledPanel</enum>
+           <enum>QFrame::Shape::StyledPanel</enum>
           </property>
           <property name="frameShadow">
-           <enum>QFrame::Plain</enum>
+           <enum>QFrame::Shadow::Plain</enum>
           </property>
           <property name="lineWidth">
            <number>0</number>
@@ -291,7 +291,7 @@
         <item row="0" column="0">
          <widget class="QSplitter" name="splitter">
           <property name="orientation">
-           <enum>Qt::Vertical</enum>
+           <enum>Qt::Orientation::Vertical</enum>
           </property>
           <property name="childrenCollapsible">
            <bool>false</bool>
@@ -337,16 +337,16 @@
                </size>
               </property>
               <property name="frameShape">
-               <enum>QFrame::NoFrame</enum>
+               <enum>QFrame::Shape::NoFrame</enum>
               </property>
               <property name="verticalScrollBarPolicy">
-               <enum>Qt::ScrollBarAsNeeded</enum>
+               <enum>Qt::ScrollBarPolicy::ScrollBarAsNeeded</enum>
               </property>
               <property name="horizontalScrollBarPolicy">
-               <enum>Qt::ScrollBarAsNeeded</enum>
+               <enum>Qt::ScrollBarPolicy::ScrollBarAsNeeded</enum>
               </property>
               <property name="verticalScrollMode">
-               <enum>QAbstractItemView::ScrollPerPixel</enum>
+               <enum>QAbstractItemView::ScrollMode::ScrollPerPixel</enum>
               </property>
               <property name="indentation">
                <number>20</number>
@@ -369,9 +369,6 @@
             <string>Add Geodata</string>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_3">
-            <property name="spacing">
-             <number>0</number>
-            </property>
             <property name="leftMargin">
              <number>0</number>
             </property>
@@ -388,22 +385,28 @@
              <widget class="QWidget" name="mGeodataToolbar" native="true">
               <layout class="QHBoxLayout" name="horizontalLayout_2">
                <property name="spacing">
-                <number>1</number>
+                <number>4</number>
                </property>
                <property name="leftMargin">
-                <number>0</number>
+                <number>4</number>
                </property>
                <property name="topMargin">
                 <number>0</number>
                </property>
                <property name="rightMargin">
-                <number>0</number>
+                <number>4</number>
                </property>
                <property name="bottomMargin">
                 <number>0</number>
                </property>
                <item>
                 <widget class="QToolButton" name="mOpenLayerButton">
+                 <property name="minimumSize">
+                  <size>
+                   <width>36</width>
+                   <height>36</height>
+                  </size>
+                 </property>
                  <property name="toolTip">
                   <string>Add Local Layer</string>
                  </property>
@@ -412,12 +415,18 @@
                    <normaloff>:/kadas/icons/open</normaloff>:/kadas/icons/open</iconset>
                  </property>
                  <property name="popupMode">
-                  <enum>QToolButton::InstantPopup</enum>
+                  <enum>QToolButton::ToolButtonPopupMode::InstantPopup</enum>
                  </property>
                 </widget>
                </item>
                <item>
                 <widget class="QToolButton" name="mAddServiceButton">
+                 <property name="minimumSize">
+                  <size>
+                   <width>36</width>
+                   <height>36</height>
+                  </size>
+                 </property>
                  <property name="toolTip">
                   <string>Add Service Layer</string>
                  </property>
@@ -426,12 +435,18 @@
                    <normaloff>:/kadas/icons/globe</normaloff>:/kadas/icons/globe</iconset>
                  </property>
                  <property name="popupMode">
-                  <enum>QToolButton::InstantPopup</enum>
+                  <enum>QToolButton::ToolButtonPopupMode::InstantPopup</enum>
                  </property>
                 </widget>
                </item>
                <item>
                 <widget class="QToolButton" name="mRefreshCatalogButton">
+                 <property name="minimumSize">
+                  <size>
+                   <width>36</width>
+                   <height>36</height>
+                  </size>
+                 </property>
                  <property name="toolTip">
                   <string>Refresh Catalog</string>
                  </property>
@@ -443,6 +458,12 @@
                </item>
                <item>
                 <widget class="QToolButton" name="mLoginButton">
+                 <property name="minimumSize">
+                  <size>
+                   <width>36</width>
+                   <height>36</height>
+                  </size>
+                 </property>
                  <property name="toolTip">
                   <string>Login</string>
                  </property>
@@ -454,6 +475,12 @@
                </item>
                <item>
                 <widget class="QToolButton" name="mLogoutButton">
+                 <property name="minimumSize">
+                  <size>
+                   <width>36</width>
+                   <height>36</height>
+                  </size>
+                 </property>
                  <property name="toolTip">
                   <string>Logout</string>
                  </property>
@@ -466,10 +493,10 @@
                <item>
                 <spacer name="horizontalSpacer_2">
                  <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
+                  <enum>Qt::Orientation::Horizontal</enum>
                  </property>
                  <property name="sizeType">
-                  <enum>QSizePolicy::Fixed</enum>
+                  <enum>QSizePolicy::Policy::Fixed</enum>
                  </property>
                  <property name="sizeHint" stdset="0">
                   <size>
@@ -485,7 +512,7 @@
                <item>
                 <spacer name="horizontalSpacer">
                  <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
+                  <enum>Qt::Orientation::Horizontal</enum>
                  </property>
                  <property name="sizeHint" stdset="0">
                   <size>
@@ -523,7 +550,7 @@
            <cursorShape>SizeHorCursor</cursorShape>
           </property>
           <property name="orientation">
-           <enum>Qt::Vertical</enum>
+           <enum>Qt::Orientation::Vertical</enum>
           </property>
          </widget>
         </item>

--- a/kadas/resources/stylesheet.css
+++ b/kadas/resources/stylesheet.css
@@ -97,12 +97,6 @@ QPushButton#mRibbonbarButton:pressed
   border: 1px solid #263B4E;
 }
 
-/*#mLayersWidget > #mLayersBox,
-#mLayersWidget > #mLayersBox > QWidget
-{
-  background-color: transparent;
-}*/
-
 #mGeodataToolbar QToolButton {
   color: #FFFFFF;
   padding: 1px 4px 1px 4px;

--- a/kadas/resources/stylesheet.css
+++ b/kadas/resources/stylesheet.css
@@ -93,15 +93,15 @@ QPushButton#mRibbonbarButton:pressed
 }
 
 #mLayersWidget {
-  background-color: rgba(255,255,255,220);
+  background-color: white;
   border: 1px solid #263B4E;
 }
 
-#mLayersWidget > #mLayersBox,
+/*#mLayersWidget > #mLayersBox,
 #mLayersWidget > #mLayersBox > QWidget
 {
   background-color: transparent;
-}
+}*/
 
 #mGeodataToolbar QToolButton {
   color: #FFFFFF;


### PR DESCRIPTION
Remove transparency for layer browser menu

Left old - right new
![image](https://github.com/user-attachments/assets/200066eb-7d38-4d47-bdac-d62634c501f5)

