### PR TITLE
Add nullptr guard

### DIFF
--- a/kadas/app/kadasmainwindow.cpp
+++ b/kadas/app/kadasmainwindow.cpp
@@ -1346,6 +1346,9 @@ void KadasMainWindow::checkLayerProjection( QgsMapLayer *layer )
 
 void KadasMainWindow::checkLayerTemporalCapabilities( QgsMapLayer *layer )
 {
+  if ( !layer->dataProvider() )
+    return;
+
   QgsDataProviderTemporalCapabilities *temporalCapabilities = layer->dataProvider()->temporalCapabilities();
 
   if ( !temporalCapabilities )


### PR DESCRIPTION
Fixes a crash when loading an invalid layer

Followup https://github.com/kadas-albireo/kadas-albireo2/pull/118

CC @domi4484 