### PR TITLE
Support 3D symbols

### DIFF
--- a/kadas/app/3d/kadas3dintegration.cpp
+++ b/kadas/app/3d/kadas3dintegration.cpp
@@ -24,6 +24,7 @@
 #include <qgis/qgscameracontroller.h>
 #include "kadas/app/3d/kadas3dmapcanvaswidget.h"
 
+#include <qgs3d.h>
 #include <qgs3dmapsettings.h>
 #include <qgs3dutils.h>
 #include <qgsmapcanvas.h>
@@ -36,6 +37,8 @@
 Kadas3DIntegration::Kadas3DIntegration( QAction *action3D, QgsMapCanvas *mapCanvas, QObject *parent )
   : QObject( parent ), mAction3D( action3D ), mMapCanvas( mapCanvas )
 {
+  Qgs3D::initialize();
+
   connect( mAction3D, &QAction::triggered, [ this ]()
   {
     if ( !m3DMapCanvasWidget )


### PR DESCRIPTION
Initialize 3D so the symbol registry is available

![image](https://github.com/user-attachments/assets/9bfd317a-febb-43fd-ba2e-bc2e97fdda26)

Symbols still need to be configured in QGIS