### PR TITLE
Fix crash on exit

### DIFF
--- a/kadas/app/3d/kadas3dmapcanvaswidget.cpp
+++ b/kadas/app/3d/kadas3dmapcanvaswidget.cpp
@@ -315,7 +315,7 @@ Kadas3DMapCanvasWidget::Kadas3DMapCanvasWidget( const QString &name, bool isDock
 
   onTotalPendingJobsCountChanged();
 
-  mDockableWidgetHelper = std::make_unique<QgsDockableWidgetHelper>( isDocked, mCanvasName, this, QgsDockableWidgetHelper::sOwnerWindow);
+  mDockableWidgetHelper = new QgsDockableWidgetHelper( isDocked, mCanvasName, this, QgsDockableWidgetHelper::sOwnerWindow);
   if ( QDialog *dialog = mDockableWidgetHelper->dialog() )
   {
     QFontMetrics fm( font() );

--- a/kadas/app/3d/kadas3dmapcanvaswidget.h
+++ b/kadas/app/3d/kadas3dmapcanvaswidget.h
@@ -62,7 +62,7 @@ class Kadas3DMapCanvasWidget : public QWidget
     Qgs3DMapToolMeasureLine *measurementLineTool() { return mMapToolMeasureLine; }
 #endif
 
-    QgsDockableWidgetHelper *dockableWidgetHelper() { return mDockableWidgetHelper.get(); }
+    QgsDockableWidgetHelper *dockableWidgetHelper() { return mDockableWidgetHelper; }
 
     void setCanvasName( const QString &name );
     QString canvasName() const { return mCanvasName; }
@@ -130,7 +130,7 @@ class Kadas3DMapCanvasWidget : public QWidget
     QAction *mActionEffects = nullptr;
     QAction *mActionOptions = nullptr;
     QAction *mActionSetSceneExtent = nullptr;
-    std::unique_ptr<QgsDockableWidgetHelper> mDockableWidgetHelper;
+    QgsDockableWidgetHelper *mDockableWidgetHelper;
     QObjectUniquePtr< QgsRubberBand > mViewFrustumHighlight;
     QObjectUniquePtr< QgsRubberBand > mViewExtentHighlight;
     QPointer<QDialog> mConfigureDialog;


### PR DESCRIPTION
The helper is parented to the widget, so it will be cleaned by Qt, if we also have the `std::unique_ptr` delete it, it will crash.