### PR TITLE
Preconfigure paths for debug sessions

### DIFF
--- a/kadas/app/CMakeLists.txt
+++ b/kadas/app/CMakeLists.txt
@@ -197,7 +197,8 @@ target_include_directories(kadas PUBLIC
 )
 
 if(WITH_VCPKG)
-  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/kadas.env.in ${CMAKE_CURRENT_BINARY_DIR}/kadas.env @ONLY)
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/kadas.env.in
+                 ${CMAKE_CURRENT_BINARY_DIR}/kadas.env @ONLY)
 endif()
 
 if(WITH_CRASHREPORT)

--- a/kadas/app/CMakeLists.txt
+++ b/kadas/app/CMakeLists.txt
@@ -196,6 +196,10 @@ target_include_directories(kadas PUBLIC
     ${CMAKE_BINARY_DIR}/kadas/app # UI are compiled there
 )
 
+if(WITH_VCPKG)
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/kadas.env.in ${CMAKE_CURRENT_BINARY_DIR}/kadas.env @ONLY)
+endif()
+
 if(WITH_CRASHREPORT)
   target_link_libraries(kadas ${CRASHRPT_LIBRARY})
   target_compile_definitions(kadas PRIVATE WITH_CRASHREPORT)

--- a/kadas/app/kadas.env.in
+++ b/kadas/app/kadas.env.in
@@ -1,0 +1,2 @@
+PYTHONPATH=@VCPKG_BASE_DIR@/tools/python3/Lib;@VCPKG_BASE_DIR@/tools/python3/Lib/site-packages
+QGIS_PREFIX_PATH=@VCPKG_BASE_DIR@

--- a/kadas/app/kadas.env.in
+++ b/kadas/app/kadas.env.in
@@ -1,2 +1,3 @@
 PYTHONPATH=@VCPKG_BASE_DIR@/tools/python3/Lib;@VCPKG_BASE_DIR@/tools/python3/Lib/site-packages
 QGIS_PREFIX_PATH=@VCPKG_BASE_DIR@
+PROJ_DATA=@VCPKG_BASE_DIR@/share/proj

--- a/kadas/app/kadaspythonintegration.cpp
+++ b/kadas/app/kadaspythonintegration.cpp
@@ -31,6 +31,10 @@
 #include "kadasapplication.h"
 #include "kadaspythonintegration.h"
 
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
+
 PyThreadState *_mainState = nullptr;
 
 
@@ -74,6 +78,9 @@ bool KadasPythonIntegration::checkSystemImports()
         runString( QStringLiteral( "sys.path.insert(0, '%1')" ).arg( prefixPath + '/' + path ) );
       }
     }
+#ifdef Q_OS_WIN
+    AddDllDirectory((const wchar_t*) QString::fromLocal8Bit( prefixPath + "/bin").utf16());
+#endif
   }
 
   // construct a list of plugin paths

--- a/kadas/app/kadaspythonintegration.cpp
+++ b/kadas/app/kadaspythonintegration.cpp
@@ -79,7 +79,7 @@ bool KadasPythonIntegration::checkSystemImports()
       }
     }
 #ifdef Q_OS_WIN
-    AddDllDirectory( static_cast<const wchar_t *>( QString::fromLocal8Bit( prefixPath + "/bin" ).utf16() ) );
+    AddDllDirectory( ( const wchar_t * ) QString::fromLocal8Bit( prefixPath + "/bin" ).utf16() );
 #endif
   }
 

--- a/kadas/app/kadaspythonintegration.cpp
+++ b/kadas/app/kadaspythonintegration.cpp
@@ -79,7 +79,7 @@ bool KadasPythonIntegration::checkSystemImports()
       }
     }
 #ifdef Q_OS_WIN
-    AddDllDirectory( ( const wchar_t * ) QString::fromLocal8Bit( prefixPath + "/bin" ).utf16() );
+    AddDllDirectory( static_cast<const wchar_t *>( QString::fromLocal8Bit( prefixPath + "/bin" ).utf16() ) );
 #endif
   }
 

--- a/kadas/app/kadaspythonintegration.cpp
+++ b/kadas/app/kadaspythonintegration.cpp
@@ -79,7 +79,7 @@ bool KadasPythonIntegration::checkSystemImports()
       }
     }
 #ifdef Q_OS_WIN
-    AddDllDirectory((const wchar_t*) QString::fromLocal8Bit( prefixPath + "/bin").utf16());
+    AddDllDirectory( ( const wchar_t * ) QString::fromLocal8Bit( prefixPath + "/bin" ).utf16() );
 #endif
   }
 

--- a/kadas/app/main.cpp
+++ b/kadas/app/main.cpp
@@ -15,6 +15,7 @@
  ***************************************************************************/
 
 #include <csignal>
+#include <fstream>
 #include <QDir>
 #include <QSettings>
 #include <QStandardPaths>
@@ -30,6 +31,29 @@
 
 int main( int argc, char *argv[] )
 {
+  try
+  {
+    std::ifstream file;
+    file.open("kadas.env");
+
+    std::string var;
+    while (std::getline(file, var))
+    {
+      if (_putenv(var.c_str()) < 0)
+      {
+        std::string message = "Could not set environment variable:" + var;
+        std::cerr << message;
+        return EXIT_FAILURE;
+      }
+    }
+  }
+  catch (std::ifstream::failure& e)
+  {
+    std::string message = std::string( "Could not read environment file ") + "`kadas.env`" + "[" + e.what() + "]";
+    std::cerr << message;
+    return EXIT_FAILURE;
+  }
+
 #ifdef Q_OS_WINDOWS
   // Clean environment
   QList<QByteArray> path = qgetenv( "PATH" ).split( ';' );

--- a/kadas/app/main.cpp
+++ b/kadas/app/main.cpp
@@ -34,12 +34,12 @@ int main( int argc, char *argv[] )
   try
   {
     std::ifstream file;
-    file.open("kadas.env");
+    file.open( "kadas.env" );
 
     std::string var;
-    while (std::getline(file, var))
+    while ( std::getline( file, var ) )
     {
-      if (_putenv(var.c_str()) < 0)
+      if ( _putenv( var.c_str() ) < 0 )
       {
         std::string message = "Could not set environment variable:" + var;
         std::cerr << message;
@@ -47,9 +47,9 @@ int main( int argc, char *argv[] )
       }
     }
   }
-  catch (std::ifstream::failure& e)
+  catch ( std::ifstream::failure &e )
   {
-    std::string message = std::string( "Could not read environment file ") + "`kadas.env`" + "[" + e.what() + "]";
+    std::string message = std::string( "Could not read environment file " ) + "`kadas.env`" + "[" + e.what() + "]";
     std::cerr << message;
     return EXIT_FAILURE;
   }

--- a/kadas/app/main.cpp
+++ b/kadas/app/main.cpp
@@ -41,11 +41,11 @@ int main( int argc, char *argv[] )
     std::string value;
     while ( std::getline( file, var ) )
     {
-      size_t pos = var.find('=');
+      size_t pos = var.find( '=' );
       if ( pos != std::string::npos )
       {
-        name = var.substr(0, pos);
-        value = var.substr(pos + 1);
+        name = var.substr( 0, pos );
+        value = var.substr( pos + 1 );
         if ( !qputenv( name.c_str(), QByteArray::fromStdString( value ) ) )
         {
           std::string message = "Could not set environment variable:" + var;

--- a/kadas/app/main.cpp
+++ b/kadas/app/main.cpp
@@ -44,8 +44,8 @@ int main( int argc, char *argv[] )
       size_t pos = var.find('=');
       if ( pos != std::string::npos )
       {
-        name = env_def.substr(0, pos);
-        value = env_def.substr(pos + 1);
+        name = var.substr(0, pos);
+        value = var.substr(pos + 1);
         if ( !qputenv( name.c_str(), QByteArray::fromStdString( value ) ) )
         {
           std::string message = "Could not set environment variable:" + var;

--- a/kadas/app/main.cpp
+++ b/kadas/app/main.cpp
@@ -37,13 +37,21 @@ int main( int argc, char *argv[] )
     file.open( "kadas.env" );
 
     std::string var;
+    std::string name;
+    std::string value;
     while ( std::getline( file, var ) )
     {
-      if ( _putenv( var.c_str() ) < 0 )
+      size_t pos = var.find('=');
+      if ( pos != std::string::npos )
       {
-        std::string message = "Could not set environment variable:" + var;
-        std::cerr << message;
-        return EXIT_FAILURE;
+        name = env_def.substr(0, pos);
+        value = env_def.substr(pos + 1);
+        if ( !qputenv( name.c_str(), QByteArray::fromStdString( value ) ) )
+        {
+          std::string message = "Could not set environment variable:" + var;
+          std::cerr << message;
+          return EXIT_FAILURE;
+        }
       }
     }
   }


### PR DESCRIPTION
Adds a new file kadas.env, this file is read on kadas start and configures environment variables.
These are used to configure PYTHONPATH and QGIS_PREFIX_PATH. These are only added to the build directory and help to find packges from vcpkg (or possibly other install trees).

This helps to start debugging in visual studio without any manual interaction.