### PR TITLE
Fix different instances of KadasMapCanvasItemManager python/c++

### DIFF
--- a/kadas/app/kadasplugininterfaceimpl.cpp
+++ b/kadas/app/kadasplugininterfaceimpl.cpp
@@ -26,6 +26,7 @@
 #include <qgis/qgsshortcutsmanager.h>
 
 #include "kadas/gui/kadasmapwidget.h"
+#include "kadas/gui/kadasmapcanvasitemmanager.h"
 
 #include "kadasapplication.h"
 #include "kadasmainwindow.h"
@@ -770,4 +771,14 @@ QList<QgsPrintLayout *> KadasPluginInterfaceImpl::printLayouts() const
 void KadasPluginInterfaceImpl::showLayoutDesigner( QgsPrintLayout *layout )
 {
   kApp->showLayoutDesigner( layout );
+}
+
+void KadasPluginInterfaceImpl::mapCanvasItemManagerAddItem( KadasMapItem *item )
+{
+  KadasMapCanvasItemManager::addItem( item );
+}
+
+void KadasPluginInterfaceImpl::mapCanvasItemManagerRemoveItem( KadasMapItem *item )
+{
+  KadasMapCanvasItemManager::removeItem( item );
 }

--- a/kadas/app/kadasplugininterfaceimpl.h
+++ b/kadas/app/kadasplugininterfaceimpl.h
@@ -376,6 +376,9 @@ class KadasPluginInterfaceImpl : public KadasPluginInterface
     bool deletePrintLayout( QgsPrintLayout *layout ) override;
     QList<QgsPrintLayout *> printLayouts() const override;
     void showLayoutDesigner( QgsPrintLayout *layout ) override;
+
+    virtual void mapCanvasItemManagerAddItem( KadasMapItem *item ) override;
+    virtual void mapCanvasItemManagerRemoveItem( KadasMapItem *item ) override;
 };
 
 

--- a/kadas/gui/kadasplugininterface.h
+++ b/kadas/gui/kadasplugininterface.h
@@ -24,6 +24,8 @@
 class QgsMapTool;
 class QgsPrintLayout;
 
+class KadasMapItem;
+
 class KADAS_GUI_EXPORT KadasPluginInterface : public QgisInterface
 {
     Q_OBJECT
@@ -96,6 +98,9 @@ class KADAS_GUI_EXPORT KadasPluginInterface : public QgisInterface
     virtual QgsRasterLayer *addRasterLayerQuiet( const QString &url, const QString &layerName, const QString &providerKey ) = 0;
     virtual QgsVectorTileLayer *addVectorTileLayerQuiet( const QString &url, const QString &baseName ) = 0;
     virtual QgsPointCloudLayer *addPointCloudLayerQuiet( const QString &url, const QString &baseName, const QString &providerKey ) = 0;
+
+    virtual void mapCanvasItemManagerAddItem( KadasMapItem *item ) = 0;
+    virtual void mapCanvasItemManagerRemoveItem( KadasMapItem *item ) = 0;
 
   signals:
     void printLayoutAdded( QgsPrintLayout *layout );

--- a/python/kadasgui/auto_generated/kadasplugininterface.sip.in
+++ b/python/kadasgui/auto_generated/kadasplugininterface.sip.in
@@ -11,6 +11,7 @@
 
 
 
+
 class KadasPluginInterface : QgisInterface
 {
 %Docstring(signature="appended")
@@ -103,6 +104,9 @@ Generic object finder
     virtual QgsRasterLayer *addRasterLayerQuiet( const QString &url, const QString &layerName, const QString &providerKey ) = 0;
     virtual QgsVectorTileLayer *addVectorTileLayerQuiet( const QString &url, const QString &baseName ) = 0;
     virtual QgsPointCloudLayer *addPointCloudLayerQuiet( const QString &url, const QString &baseName, const QString &providerKey ) = 0;
+
+    virtual void mapCanvasItemManagerAddItem( KadasMapItem *item ) = 0;
+    virtual void mapCanvasItemManagerRemoveItem( KadasMapItem *item ) = 0;
 
   signals:
     void printLayoutAdded( QgsPrintLayout *layout );

--- a/share/python/plugins/kadas_ephem/ephem_tool.py
+++ b/share/python/plugins/kadas_ephem/ephem_tool.py
@@ -31,7 +31,7 @@ class EphemTool(QgsMapTool):
         self.pin = KadasSymbolItem(self.iface.mapCanvas().mapSettings().destinationCrs())
         self.pin.setup( ":/kadas/icons/pin_blue", 0.5, 1.0 );
         self.pin.setVisible(False)
-        KadasMapCanvasItemManager.addItem(self.pin)
+        self.iface.mapCanvasItemManagerAddItem(self.pin)
 
         QgsMapTool.activate(self)
 
@@ -39,7 +39,7 @@ class EphemTool(QgsMapTool):
         if self.widget:
             self.widget.cleanup()
             self.widget = None
-        KadasMapCanvasItemManager.removeItem(self.pin)
+        self.iface.mapCanvasItemManagerRemoveItem(self.pin)
         self.pin = None
         QgsMapTool.deactivate(self)
 
@@ -116,11 +116,11 @@ class EphemToolWidget(KadasBottomBar):
         self.sunAzIcon = KadasSymbolItem(QgsCoordinateReferenceSystem("EPSG:4326"))
         self.sunAzIcon.setup( ":/plugins/Ephem/icons/az_sun.svg", 0.5, 1.0 );
         self.sunAzIcon.setVisible(False)
-        KadasMapCanvasItemManager.addItem(self.sunAzIcon)
+        self.iface.mapCanvasItemManagerAddItem(self.sunAzIcon)
 
         self.moonAzIcon = KadasSymbolItem(QgsCoordinateReferenceSystem("EPSG:4326"))
         self.moonAzIcon.setup( ":/plugins/Ephem/icons/az_moon.svg", 0.5, 1.0 );
-        KadasMapCanvasItemManager.addItem(self.moonAzIcon)
+        self.iface.mapCanvasItemManagerAddItem(self.moonAzIcon)
         self.moonAzIcon.setVisible(False)
 
     def getTimestamp(self):
@@ -137,9 +137,9 @@ class EphemToolWidget(KadasBottomBar):
         self.mrcPos = mrcPos
 
     def cleanup(self):
-        KadasMapCanvasItemManager.removeItem(self.sunAzIcon)
+        self.iface.mapCanvasItemManagerRemoveItem(self.sunAzIcon)
         self.sunAzIcon = None
-        KadasMapCanvasItemManager.removeItem(self.moonAzIcon)
+        self.iface.mapCanvasItemManagerRemoveItem(self.moonAzIcon)
         self.moonAzIcon = None
 
     def recompute(self):


### PR DESCRIPTION
For some reason the instance of KadasMapCanvasItemManager that should be a singleton was different between C++ and python