### PR TITLE
Fix mapswipe tool

### DIFF
--- a/kadas/app/mapswipe/kadasmapswipecanvasitem.h
+++ b/kadas/app/mapswipe/kadasmapswipecanvasitem.h
@@ -23,6 +23,7 @@
 #include <qgsmapcanvasitem.h>
 
 class QgsMapLayer;
+class QgsMapRendererParallelJob;
 
 class KadasMapSwipeCanvasItem : public QgsMapCanvasItem
 {
@@ -54,6 +55,9 @@ class KadasMapSwipeCanvasItem : public QgsMapCanvasItem
     QSet<QgsMapLayer *> mRemovedLayers;
     bool mIsVertical = true;
     QImage mRenderedMapImage;
+    QgsMapRendererParallelJob *mRenderJob = nullptr;
+    QMetaObject::Connection mRenderJobFinishedConnection;
+    QMetaObject::Connection mRenderJobUpdatedConnection;
 };
 
 #endif // KADASMAPSWIPECANVASITEM_H


### PR DESCRIPTION
Render in background and make use of rendercache of alrady rendered mapcanvas image

The `waitForFinished` call was blocking the main thread until we'd have a fully rendered image, which could take a long time, especially with remote layers.