### PR TITLE
Fix tilted 3D screen to world coord

### DIFF
--- a/vcpkg/ports/qgis/fix3dnavigation.patch
+++ b/vcpkg/ports/qgis/fix3dnavigation.patch
@@ -1,0 +1,37 @@
+diff --git a/src/3d/qgs3dutils.cpp b/src/3d/qgs3dutils.cpp
+index e4077922891..1d60d591a53 100644
+--- a/src/3d/qgs3dutils.cpp
++++ b/src/3d/qgs3dutils.cpp
+@@ -745,15 +745,26 @@ QgsRay3D Qgs3DUtils::rayFromScreenPoint( const QPoint &point, const QSize &windo
+ 
+ QVector3D Qgs3DUtils::screenPointToWorldPos( const QPoint &screenPoint, double depth, const QSize &screenSize, Qt3DRender::QCamera *camera )
+ {
+-  double dNear = camera->nearPlane();
+-  double dFar = camera->farPlane();
+-  double distance = ( 2.0 * dNear * dFar ) / ( dFar + dNear - ( depth * 2 - 1 ) * ( dFar - dNear ) );
++  if ( !camera || screenSize.width() <= 0 || screenSize.height() <= 0 )
++    return QVector3D(); // Handle invalid input
+ 
+   QgsRay3D ray = Qgs3DUtils::rayFromScreenPoint( screenPoint, screenSize, camera );
+-  double dot = QVector3D::dotProduct( ray.direction(), camera->viewVector().normalized() );
+-  distance /= dot;
+ 
+-  return ray.origin() + distance * ray.direction();
++  // Assume we're finding the intersection with a ground plane at Z = 0
++  QVector3D planeNormal( 0, 0, 1 );
++  QVector3D planePoint( 0, 0, 0 );
++
++  double denom = QVector3D::dotProduct( ray.direction(), planeNormal );
++
++  if ( qFuzzyIsNull( denom ) )
++    return QVector3D(); // Ray is parallel to the ground plane, return invalid point
++
++  double t = QVector3D::dotProduct( planePoint - ray.origin(), planeNormal ) / denom;
++
++  if ( t < 0 )
++    return QVector3D(); // Intersection is behind the camera, return invalid point
++
++  return ray.origin() + t * ray.direction(); // Compute final world position
+ }
+ 
+ void Qgs3DUtils::pitchAndYawFromViewVector( QVector3D vect, double &pitch, double &yaw )

--- a/vcpkg/ports/qgis/portfile.cmake
+++ b/vcpkg/ports/qgis/portfile.cmake
@@ -29,6 +29,7 @@ vcpkg_from_github(
   nlohmann-json.patch
   qgis-debug.patch
   locator-bold-pr60689.patch
+  fix3dnavigation.patch
 )
 
 file(REMOVE ${SOURCE_PATH}/cmake/FindGDAL.cmake)


### PR DESCRIPTION
Fixes the calculation of the ground point (Z=0) at a given screen position also when the camera is tilted.
This massively improves the navigation usability.

There is still room for improvement. We now take the Z=0 point, but it would be even better to take a terrain point.