### PR TITLE
Use vector variant for arcgis layers

### DIFF
--- a/kadas/app/kadasmainwindow.cpp
+++ b/kadas/app/kadasmainwindow.cpp
@@ -1206,18 +1206,28 @@ void KadasMainWindow::addCatalogLayer( const QgsMimeDataUtils::Uri &uri, const Q
   {
     // If there is exactly one sublayer, add it directly
     QVariantMap sublayer = sublayers[0].toMap();
+
+    QgsMapLayer *layer = nullptr;
     if ( uri.providerKey == "arcgismapserver" )
     {
       QgsDataSourceUri dataSource( adjustedUri );
       dataSource.removeParam( "layer" );
       dataSource.setParam( "layer", QString::number( sublayer["id"].toInt() ) );
       adjustedUri = dataSource.uri();
+      layer = kApp->addRasterLayer( adjustedUri, uri.name, uri.providerKey, false, 0, false );
+    }
+    else if ( uri.providerKey == "arcgisfeatureserver" )
+    {
+      QgsDataSourceUri dataSource( adjustedUri );
+      adjustedUri = dataSource.uri();
+      layer = kApp->addVectorLayer( adjustedUri, uri.name, uri.providerKey, false, 0, false );
     }
     else if ( uri.providerKey == "wms" )
     {
       adjustedUri.replace( QRegExp( "layers=[^&]*" ), "layers=" + sublayer["id"].toString() );
+      layer = kApp->addRasterLayer( adjustedUri, uri.name, uri.providerKey, false, 0, false );
     }
-    QgsRasterLayer *layer = kApp->addRasterLayer( adjustedUri, uri.name, uri.providerKey, false, 0, false );
+
     if ( layer )
     {
       layer->setMetadataUrl( metadataUrl );
@@ -1276,19 +1286,28 @@ void KadasMainWindow::addCatalogLayer( const QgsMimeDataUtils::Uri &uri, const Q
       }
       if ( entry->leaf )
       {
+        QgsMapLayer *layer = nullptr;
         if ( uri.providerKey == "arcgismapserver" )
         {
           QgsDataSourceUri dataSource( adjustedUri );
           dataSource.removeParam( "layer" );
           dataSource.setParam( "layer", QString::number( entry->id ) );
           adjustedUri = dataSource.uri();
+          layer = kApp->addRasterLayer( adjustedUri, entry->name, uri.providerKey, false, 0, false );
+        }
+        else if ( uri.providerKey == "arcgisfeatureserver" )
+        {
+          QgsDataSourceUri dataSource( adjustedUri );
+          adjustedUri = dataSource.uri();
+          layer = kApp->addVectorLayer( adjustedUri, entry->name, uri.providerKey, false, 0, false );
         }
         else if ( uri.providerKey == "wms" )
         {
           adjustedUri.replace( QRegExp( "layers=[^&]*" ), "layers=" + QString::number( entry->id ) );
+          layer = kApp->addRasterLayer( adjustedUri, entry->name, uri.providerKey, false, 0, false );
         }
+
         QgsProject::instance()->layerTreeRegistryBridge()->setLayerInsertionPoint( QgsLayerTreeRegistryBridge::InsertionPoint( parent, parent == rootGroup ? rootInsCount++ : parent->children().count() ) );
-        QgsRasterLayer *layer = kApp->addRasterLayer( adjustedUri, entry->name, uri.providerKey, false, 0, false );
         if ( layer )
         {
           layer->setMetadataUrl( metadataUrl );

--- a/kadas/gui/catalog/kadasarcgisportalcatalogprovider.cpp
+++ b/kadas/gui/catalog/kadasarcgisportalcatalogprovider.cpp
@@ -415,11 +415,22 @@ void KadasArcGisPortalCatalogProvider::readAMSCapabilitiesDo()
     }
 
     QgsMimeDataUtils::Uri mimeDataUri;
-    mimeDataUri.layerType = "raster";
-    mimeDataUri.providerKey = "arcgismapserver";
     mimeDataUri.name = entry->title;
-    QString format = filteredEncodings.isEmpty() || filteredEncodings.contains( "png32" ) ? "png32" : filteredEncodings.values().front();
-    mimeDataUri.uri = QString( "crs='%1' format='%2' url='%3' layer='0'" ).arg( crs.authid() ).arg( format ).arg( url );
+
+    if ( KadasCatalogBrowser::sSettingLoadArcgisLayerAsVector->value() )
+    {
+      mimeDataUri.layerType = "vector";
+      mimeDataUri.providerKey = "arcgisfeatureserver";
+      mimeDataUri.uri = QString( "crs='%1' url='%2/0'" ).arg( crs.authid() ).arg( url );
+    }
+    else
+    {
+      mimeDataUri.layerType = "raster";
+      mimeDataUri.providerKey = "arcgismapserver";
+      QString format = filteredEncodings.isEmpty() || filteredEncodings.contains( "png32" ) ? "png32" : filteredEncodings.values().front();
+      mimeDataUri.uri = QString( "crs='%1' format='%2' url='%3' layer='0'" ).arg( crs.authid() ).arg( format ).arg( url );
+    }
+
     QMimeData *mimeData = QgsMimeDataUtils::encodeUriList( QgsMimeDataUtils::UriList() << mimeDataUri );
     if ( !entry->flatten )
     {

--- a/kadas/gui/catalog/kadasvbscatalogprovider.cpp
+++ b/kadas/gui/catalog/kadasvbscatalogprovider.cpp
@@ -271,12 +271,24 @@ void KadasVBSCatalogProvider::readAMSCapabilitiesDo()
     for ( const QString &layerName : entries->keys() )
     {
       QgsMimeDataUtils::Uri mimeDataUri;
-      mimeDataUri.layerType = "raster";
-      mimeDataUri.providerKey = "arcgismapserver";
+
+      if ( KadasCatalogBrowser::sSettingLoadArcgisLayerAsVector->value() )
+      {
+        mimeDataUri.layerType = "vector";
+        mimeDataUri.providerKey = "arcgisfeatureserver";
+        mimeDataUri.uri = QString( "crs='%1' url='%2/0' layer='%3'" ).arg( crs.authid() ).arg( url ).arg( layerName );
+      }
+      else
+      {
+        mimeDataUri.layerType = "raster";
+        mimeDataUri.providerKey = "arcgismapserver";
+        QString format = filteredEncodings.isEmpty() || filteredEncodings.contains( "png" ) ? "png" : filteredEncodings.values().front();
+        mimeDataUri.uri = QString( "crs='%1' format='%2' url='%3' layer='%4'" ).arg( crs.authid() ).arg( format ).arg( url ).arg( layerName );
+      }
+
       const ResultEntry &entry = ( *entries )[layerName];
       mimeDataUri.name = entry.title;
-      QString format = filteredEncodings.isEmpty() || filteredEncodings.contains( "png" ) ? "png" : filteredEncodings.values().front();
-      mimeDataUri.uri = QString( "crs='%1' format='%2' url='%3' layer='%4'" ).arg( crs.authid() ).arg( format ).arg( url ).arg( layerName );
+
       QMimeData *mimeData = QgsMimeDataUtils::encodeUriList( QgsMimeDataUtils::UriList() << mimeDataUri );
       mimeData->setProperty( "metadataUrl", entry.metadataUrl );
       if ( !entry.flatten )

--- a/kadas/gui/kadascatalogbrowser.h
+++ b/kadas/gui/kadascatalogbrowser.h
@@ -21,8 +21,10 @@
 #include <QWidget>
 
 #include <qgis/qgsmimedatautils.h>
+#include <qgis/qgssettingsentryimpl.h>
 
 #include "kadas/gui/kadas_gui.h"
+#include "kadas/core/kadassettingstree.h"
 
 class KadasCatalogProvider;
 class QgsFilterLineEdit;
@@ -33,6 +35,8 @@ class KADAS_GUI_EXPORT KadasCatalogBrowser : public QWidget
 {
     Q_OBJECT
   public:
+    static const inline QgsSettingsEntryBool *sSettingLoadArcgisLayerAsVector = new QgsSettingsEntryBool( QStringLiteral( "load-arcgis-layer-as-vector" ), KadasSettingsTree::sTreePortal, true );
+
     KadasCatalogBrowser( QWidget *parent = 0 );
     void addProvider( KadasCatalogProvider *provider ) { mProviders.append( provider ); }
     QStandardItem *addItem( QStandardItem *parent, QString text, int sortIndex, bool isLeaf = false, QMimeData *mimeData = nullptr );


### PR DESCRIPTION
It works for geocatalogs of type `arcgisportal`.
I could not test it with geocatalogs of type `vbs`. In the default settings_full.ini there is no such catalog configured.

I added a settings `portal/load-arcgis-layer-as-vector` if someone need to work with the layers as raster. Or to quickly switch back in case of issues.