### PR TITLE
Differentiate arcgis Vector/Raster layers

### DIFF
--- a/kadas/app/kadasapplication.cpp
+++ b/kadas/app/kadasapplication.cpp
@@ -1128,9 +1128,18 @@ int KadasApplication::dialogPanelIndex( const QString &name, QStackedWidget *sta
 void KadasApplication::showLayerInfo( const QgsMapLayer *layer )
 {
   QString layerUrl;
-  if ( layer->providerType() == "arcgismapserver" || layer->providerType() == "arcgisfeatureserver" )
+  if ( layer->providerType() == "arcgismapserver" )
   {
     layerUrl = QgsDataSourceUri( layer->source() ).param( "url" );
+  }
+  else if ( layer->providerType() == "arcgisfeatureserver" )
+  {
+    layerUrl = QgsDataSourceUri( layer->source() ).param( "url" );
+    int lastIndex = layerUrl.lastIndexOf( QRegExp( "\\/\\d+\\/{0,1}$" ) ); // Chop the layer index ../MapServer/4
+    if ( lastIndex >= 0 )
+    {
+      layerUrl = layerUrl.left( lastIndex );
+    }
   }
   else if ( layer->providerType() == "wms" )
   {

--- a/kadas/app/kadasmainwindow.cpp
+++ b/kadas/app/kadasmainwindow.cpp
@@ -1296,8 +1296,9 @@ void KadasMainWindow::addCatalogLayer( const QgsMimeDataUtils::Uri &uri, const Q
         if ( uri.providerKey == "arcgismapserver" )
         {
           QgsDataSourceUri dataSource( adjustedUri );
-          dataSource.removeParam( "layer" );
-          dataSource.setParam( "layer", QString::number( entry->id ) );
+          QString urlParameter = QString( "%1/%2" ).arg( dataSource.param( "url" ) ).arg( entry->id );
+          dataSource.removeParam( "url" );
+          dataSource.setParam( "url", urlParameter );
           adjustedUri = dataSource.uri();
           layer = kApp->addRasterLayer( adjustedUri, entry->name, uri.providerKey, false, 0, false );
         }

--- a/kadas/app/kadasmainwindow.cpp
+++ b/kadas/app/kadasmainwindow.cpp
@@ -1304,6 +1304,8 @@ void KadasMainWindow::addCatalogLayer( const QgsMimeDataUtils::Uri &uri, const Q
         else if ( uri.providerKey == "arcgisfeatureserver" )
         {
           QgsDataSourceUri dataSource( adjustedUri );
+          dataSource.removeParam( "layer" );
+          dataSource.setParam( "layer", QString::number( entry->id ) );
           adjustedUri = dataSource.uri();
           layer = kApp->addVectorLayer( adjustedUri, entry->name, uri.providerKey, false, 0, false );
         }

--- a/kadas/app/kadasmainwindow.cpp
+++ b/kadas/app/kadasmainwindow.cpp
@@ -1293,6 +1293,8 @@ void KadasMainWindow::addCatalogLayer( const QgsMimeDataUtils::Uri &uri, const Q
       }
       if ( entry->leaf )
       {
+        QgsProject::instance()->layerTreeRegistryBridge()->setLayerInsertionPoint( QgsLayerTreeRegistryBridge::InsertionPoint( parent, parent == rootGroup ? rootInsCount++ : parent->children().count() ) );
+
         QgsMapLayer *layer = nullptr;
         if ( uri.providerKey == "arcgismapserver" )
         {
@@ -1319,7 +1321,6 @@ void KadasMainWindow::addCatalogLayer( const QgsMimeDataUtils::Uri &uri, const Q
           layer = kApp->addRasterLayer( adjustedUri, entry->name, uri.providerKey, false, 0, false );
         }
 
-        QgsProject::instance()->layerTreeRegistryBridge()->setLayerInsertionPoint( QgsLayerTreeRegistryBridge::InsertionPoint( parent, parent == rootGroup ? rootInsCount++ : parent->children().count() ) );
         if ( layer )
         {
           layer->setMetadataUrl( metadataUrl );

--- a/kadas/app/kadasmainwindow.cpp
+++ b/kadas/app/kadasmainwindow.cpp
@@ -1223,7 +1223,7 @@ void KadasMainWindow::addCatalogLayer( const QgsMimeDataUtils::Uri &uri, const Q
       QString urlParameter = QString( "%1/%2" ).arg( dataSource.param( "url" ) ).arg( sublayer["id"].toInt() );
       dataSource.removeParam( "url" );
       dataSource.setParam( "url", urlParameter );
-      layer = kApp->addVectorLayer( adjustedUri, uri.name, uri.providerKey, false, 0, false );
+      layer = kApp->addVectorLayer( dataSource.uri(), uri.name, uri.providerKey, false, 0, false );
     }
     else if ( uri.providerKey == "arcgisvectortileservice" )
     {

--- a/kadas/app/kadasmainwindow.cpp
+++ b/kadas/app/kadasmainwindow.cpp
@@ -1215,13 +1215,14 @@ void KadasMainWindow::addCatalogLayer( const QgsMimeDataUtils::Uri &uri, const Q
       QgsDataSourceUri dataSource( adjustedUri );
       dataSource.removeParam( "layer" );
       dataSource.setParam( "layer", QString::number( sublayer["id"].toInt() ) );
-      adjustedUri = dataSource.uri();
-      layer = kApp->addRasterLayer( adjustedUri, uri.name, uri.providerKey, false, 0, false );
+      layer = kApp->addRasterLayer( dataSource.uri(), uri.name, uri.providerKey, false, 0, false );
     }
     else if ( uri.providerKey == "arcgisfeatureserver" )
     {
       QgsDataSourceUri dataSource( adjustedUri );
-      adjustedUri = dataSource.uri();
+      QString urlParameter = QString( "%1/%2" ).arg( dataSource.param( "url" ) ).arg( sublayer["id"].toInt() );
+      dataSource.removeParam( "url" );
+      dataSource.setParam( "url", urlParameter );
       layer = kApp->addVectorLayer( adjustedUri, uri.name, uri.providerKey, false, 0, false );
     }
     else if ( uri.providerKey == "arcgisvectortileservice" )
@@ -1296,19 +1297,17 @@ void KadasMainWindow::addCatalogLayer( const QgsMimeDataUtils::Uri &uri, const Q
         if ( uri.providerKey == "arcgismapserver" )
         {
           QgsDataSourceUri dataSource( adjustedUri );
-          QString urlParameter = QString( "%1/%2" ).arg( dataSource.param( "url" ) ).arg( entry->id );
-          dataSource.removeParam( "url" );
-          dataSource.setParam( "url", urlParameter );
-          adjustedUri = dataSource.uri();
-          layer = kApp->addRasterLayer( adjustedUri, entry->name, uri.providerKey, false, 0, false );
+          dataSource.removeParam( "layer" );
+          dataSource.setParam( "layer", QString::number( entry->id ) );
+          layer = kApp->addRasterLayer( dataSource.uri(), entry->name, uri.providerKey, false, 0, false );
         }
         else if ( uri.providerKey == "arcgisfeatureserver" )
         {
           QgsDataSourceUri dataSource( adjustedUri );
-          dataSource.removeParam( "layer" );
-          dataSource.setParam( "layer", QString::number( entry->id ) );
-          adjustedUri = dataSource.uri();
-          layer = kApp->addVectorLayer( adjustedUri, entry->name, uri.providerKey, false, 0, false );
+          QString urlParameter = QString( "%1/%2" ).arg( dataSource.param( "url" ) ).arg( entry->id );
+          dataSource.removeParam( "url" );
+          dataSource.setParam( "url", urlParameter );
+          layer = kApp->addVectorLayer( dataSource.uri(), entry->name, uri.providerKey, false, 0, false );
         }
         else if ( uri.providerKey == "arcgisvectortileservice" )
         {

--- a/kadas/gui/catalog/kadasarcgisportalcatalogprovider.cpp
+++ b/kadas/gui/catalog/kadasarcgisportalcatalogprovider.cpp
@@ -23,6 +23,7 @@
 #include <QNetworkRequest>
 #include <QNetworkReply>
 #include <QUrlQuery>
+#include <QDebug>
 
 #include <qgis/qgscoordinatereferencesystem.h>
 #include <qgis/qgsnetworkaccessmanager.h>
@@ -357,6 +358,11 @@ void KadasArcGisPortalCatalogProvider::readAMSCapabilitiesDo()
 
   if ( reply->error() == QNetworkReply::NoError )
   {
+    qDebug() << "REQUEST:" << reply->request().url();
+
+    // auto completeReply = reply->readAll();
+    // qDebug() << "REPLY:  " << completeReply;
+
     QVariantMap serviceInfoMap = QJsonDocument::fromJson( reply->readAll() ).object().toVariantMap();
 
     if ( !serviceInfoMap["error"].isNull() )

--- a/kadas/gui/catalog/kadasarcgisportalcatalogprovider.cpp
+++ b/kadas/gui/catalog/kadasarcgisportalcatalogprovider.cpp
@@ -411,6 +411,7 @@ void KadasArcGisPortalCatalogProvider::readAMSCapabilitiesDo()
 
     // Parse sublayers
     QVariantList sublayers;
+    bool typeVector = true;
     for ( QVariant variant : serviceInfoMap["layers"].toList() )
     {
       QVariantMap entry = variant.toMap();
@@ -419,12 +420,17 @@ void KadasArcGisPortalCatalogProvider::readAMSCapabilitiesDo()
       sublayer["parentLayerId"] = entry["parentLayerId"];
       sublayer["name"] = entry["name"];
       sublayers.append( sublayer );
+
+      if ( entry["type"] == "Raster Layer" )
+      {
+        typeVector = false;
+      }
     }
 
     QgsMimeDataUtils::Uri mimeDataUri;
     mimeDataUri.name = entry->title;
 
-    if ( KadasCatalogBrowser::sSettingLoadArcgisLayerAsVector->value() )
+    if ( typeVector )
     {
       mimeDataUri.layerType = "vector";
       mimeDataUri.providerKey = "arcgisfeatureserver";

--- a/kadas/gui/catalog/kadasarcgisportalcatalogprovider.cpp
+++ b/kadas/gui/catalog/kadasarcgisportalcatalogprovider.cpp
@@ -428,7 +428,7 @@ void KadasArcGisPortalCatalogProvider::readAMSCapabilitiesDo()
     {
       mimeDataUri.layerType = "vector";
       mimeDataUri.providerKey = "arcgisfeatureserver";
-      mimeDataUri.uri = QString( "crs='%1' url='%2/0'" ).arg( crs.authid() ).arg( url );
+      mimeDataUri.uri = QString( "crs='%1' url='%2'" ).arg( crs.authid() ).arg( url );
     }
     else
     {

--- a/kadas/gui/catalog/kadasvbscatalogprovider.cpp
+++ b/kadas/gui/catalog/kadasvbscatalogprovider.cpp
@@ -258,6 +258,7 @@ void KadasVBSCatalogProvider::readAMSCapabilitiesDo()
 
     // Parse sublayers
     QList<QVariantMap> sublayers;
+    bool typeVector = true;
     for ( QVariant variant : serviceInfoMap["layers"].toList() )
     {
       QVariantMap entry = variant.toMap();
@@ -266,13 +267,18 @@ void KadasVBSCatalogProvider::readAMSCapabilitiesDo()
       sublayer["parentLayerId"] = entry["parentLayerId"];
       sublayer["name"] = entry["name"];
       sublayers.append( sublayer );
+
+      if ( entry["type"] == "Raster Layer" )
+      {
+        typeVector = false;
+      }
     }
 
     for ( const QString &layerName : entries->keys() )
     {
       QgsMimeDataUtils::Uri mimeDataUri;
 
-      if ( KadasCatalogBrowser::sSettingLoadArcgisLayerAsVector->value() )
+      if ( typeVector )
       {
         mimeDataUri.layerType = "vector";
         mimeDataUri.providerKey = "arcgisfeatureserver";

--- a/kadas/gui/kadascatalogbrowser.h
+++ b/kadas/gui/kadascatalogbrowser.h
@@ -21,10 +21,8 @@
 #include <QWidget>
 
 #include <qgis/qgsmimedatautils.h>
-#include <qgis/qgssettingsentryimpl.h>
 
 #include "kadas/gui/kadas_gui.h"
-#include "kadas/core/kadassettingstree.h"
 
 class KadasCatalogProvider;
 class QgsFilterLineEdit;
@@ -35,7 +33,6 @@ class KADAS_GUI_EXPORT KadasCatalogBrowser : public QWidget
 {
     Q_OBJECT
   public:
-    static const inline QgsSettingsEntryBool *sSettingLoadArcgisLayerAsVector = new QgsSettingsEntryBool( QStringLiteral( "load-arcgis-layer-as-vector" ), KadasSettingsTree::sTreePortal, true );
 
     KadasCatalogBrowser( QWidget *parent = 0 );
     void addProvider( KadasCatalogProvider *provider ) { mProviders.append( provider ); }


### PR DESCRIPTION
- Use "type" to differentiate arcgis Raster/Vector layers and use "arcgismapserver"/"arcgisfeatureserver" accordingly
- Remove related settings as no longer needed
- Fix first layer insertion point for groups
- Fix sublayer index in groups (for arcgisfeatureserver)
- Fix Layer infos not working for feature layers: EbenenInformationen: Keine Informationen für diese Ebene verfügbar