### PR TITLE
Fix the 3d frustum calculation when close to origin

### DIFF
--- a/vcpkg/ports/qgis/3dfrustumfix.patch
+++ b/vcpkg/ports/qgis/3dfrustumfix.patch
@@ -1,0 +1,18 @@
+diff --git a/src/3d/qgs3dmapscene.cpp b/src/3d/qgs3dmapscene.cpp
+index 89899b0d6ec..a1d3f425a72 100644
+--- a/src/3d/qgs3dmapscene.cpp
++++ b/src/3d/qgs3dmapscene.cpp
+@@ -270,6 +270,13 @@ QVector<QgsPointXY> Qgs3DMapScene::viewFrustum2DExtent() const
+     const QPoint p( ( ( i >> 0 ) & 1 ) ? 0 : mEngine->size().width(), ( ( i >> 1 ) & 1 ) ? 0 : mEngine->size().height() );
+     QgsRay3D ray = Qgs3DUtils::rayFromScreenPoint( p, mEngine->size(), camera );
+     QVector3D dir = ray.direction();
++
++    // Push ray origin slightly below plane to prevent degenerate projection
++    if ( std::abs(ray.origin().z()) < 1e-5 )
++    {
++      ray.setOrigin( ray.origin() + QVector3D(0, 0, -0.01) );
++    }
++
+     if ( dir.z() == 0.0 )
+       dir.setZ( 0.000001 );
+     double t = -ray.origin().z() / dir.z();

--- a/vcpkg/ports/qgis/portfile.cmake
+++ b/vcpkg/ports/qgis/portfile.cmake
@@ -31,6 +31,7 @@ vcpkg_from_github(
   depth_render_frag.patch
   62506.patch # https://jira.swisstopo.ch/browse/MGDIGRE_SB-1262
   sync_2d_3d.patch # https://github.com/qgis/QGIS/pull/62530
+  3dfrustumfix.patch
 )
 
 file(REMOVE ${SOURCE_PATH}/cmake/FindGDAL.cmake)


### PR DESCRIPTION
Fixes a problem with frustum terrain (z=0 plane) intersection, where if the camera is too close to the origin we get into a floating point calculation precision problem.
An alternative approach would be #315 which completely disables origin shift. This seems to work nicely as well, but the origin shift functionality promises better results for large scenes (>50km) which we want to be able to handle.