### PR TITLE
3D: fix layer tree sync + dialog title + layer tree view state

### DIFF
--- a/kadas/app/3d/kadas3dintegration.cpp
+++ b/kadas/app/3d/kadas3dintegration.cpp
@@ -39,7 +39,7 @@
 #include "kadas/app/3d/kadas3dintegration.h"
 #include "kadas/app/3d/kadas3dmapcanvaswidget.h"
 
-static const QString KADAS_3D_IDENTIFIER = QStringLiteral( "kadas-3d" );
+static const QString KADAS_3D_IDENTIFIER = QStringLiteral( "Kadas 3D" );
 
 void write3DMapViewSettings( Kadas3DMapCanvasWidget *widget, QDomDocument &doc, QDomElement &elem3DMap )
 {

--- a/kadas/app/3d/kadas3dlayertreemodel.cpp
+++ b/kadas/app/3d/kadas3dlayertreemodel.cpp
@@ -25,8 +25,10 @@ Kadas3DLayerTreeModel::Kadas3DLayerTreeModel( Qgs3DMapCanvas *mapCanvas )
 
   setLayerTreeModel( new QgsLayerTreeModel( QgsProject::instance()->layerTreeRoot(), this ) );
   connect( QgsProject::instance(), &QgsProject::readProject, this, [=] {
+    beginResetModel();
     mShownLayers.clear();
-    resetLayerTreeModel();
+    visibleLayers( QgsProject::instance()->layerTreeRoot(), mShownLayers );
+    endResetModel();
   } );
 }
 

--- a/kadas/app/3d/kadas3dlayertreemodel.cpp
+++ b/kadas/app/3d/kadas3dlayertreemodel.cpp
@@ -43,6 +43,10 @@ Qt::ItemFlags Kadas3DLayerTreeModel::flags( const QModelIndex &idx ) const
 {
   if ( idx.column() == 0 )
   {
+    if ( !mapLayer( idx ) )
+      return Qt::ItemIsEnabled;
+
+    // if this is a layer, allow check state
     return Qt::ItemIsEnabled | Qt::ItemIsUserCheckable;
   }
 
@@ -170,47 +174,6 @@ QVariant Kadas3DLayerTreeModel::data( const QModelIndex &idx, int role ) const
       {
         return mShownLayers.contains( layer ) ? Qt::Checked : Qt::Unchecked;
       }
-      else
-      {
-        // i.e. this is a group, analyze its children
-        bool hasChecked = false, hasUnchecked = false;
-        int n;
-        for ( n = 0; !hasChecked || !hasUnchecked; n++ )
-        {
-          QModelIndex childIdx = index( n, 0, idx );
-          if ( !childIdx.isValid() )
-            break;
-          const QVariant v = data( childIdx, role );
-
-          switch ( v.value<Qt::CheckState>() )
-          {
-            case Qt::PartiallyChecked:
-              // parent of partially checked child shared state
-              return Qt::PartiallyChecked;
-
-            case Qt::Checked:
-              hasChecked = true;
-              break;
-
-            case Qt::Unchecked:
-              hasUnchecked = true;
-              break;
-          }
-        }
-        // unchecked leaf
-        if ( n == 0 )
-          return Qt::Unchecked;
-
-        // both
-        if ( hasChecked && hasUnchecked )
-          return Qt::PartiallyChecked;
-
-        if ( hasChecked )
-          return Qt::Checked;
-
-        Q_ASSERT( hasUnchecked );
-        return Qt::Unchecked;
-      }
     }
     else
     {
@@ -227,30 +190,17 @@ bool Kadas3DLayerTreeModel::setData( const QModelIndex &index, const QVariant &v
   {
     if ( static_cast<Qt::ItemDataRole>( role ) == Qt::ItemDataRole::CheckStateRole )
     {
-      int i = 0;
-      for ( i = 0;; i++ )
-      {
-        const QModelIndex child = Kadas3DLayerTreeModel::index( i, 0, index );
-        if ( !child.isValid() )
-          break;
+      QgsMapLayer *layer = mapLayer( index );
+      if ( !layer )
+        return false;
 
-        setData( child, value, role );
-      }
+      if ( value.value<Qt::CheckState>() == Qt::Checked )
+        mShownLayers.insert( layer );
+      else if ( value.value<Qt::CheckState>() == Qt::Unchecked )
+        mShownLayers.remove( layer );
+      else
+        Q_ASSERT( false ); // expected checked or unchecked
 
-      if ( i == 0 )
-      {
-        QgsMapLayer *layer = mapLayer( index );
-        if ( !layer )
-        {
-          return false;
-        }
-        if ( value.value<Qt::CheckState>() == Qt::Checked )
-          mShownLayers.insert( layer );
-        else if ( value.value<Qt::CheckState>() == Qt::Unchecked )
-          mShownLayers.remove( layer );
-        else
-          Q_ASSERT( false ); // expected checked or unchecked
-      }
       emit dataChanged( index, index );
 
       // create a new map theme and use it 3D

--- a/kadas/app/3d/kadas3dlayertreemodel.cpp
+++ b/kadas/app/3d/kadas3dlayertreemodel.cpp
@@ -163,12 +163,12 @@ QVariant Kadas3DLayerTreeModel::data( const QModelIndex &idx, int role ) const
 {
   if ( idx.column() == 0 )
   {
-    if ( role == Qt::CheckStateRole )
+    if ( static_cast<Qt::ItemDataRole>( role ) == Qt::ItemDataRole::CheckStateRole )
     {
       QgsMapLayer *layer = mapLayer( idx );
       if ( layer )
       {
-        return mShownLayers.contains( layer ) ? Qt::Checked ::Qt::Unchecked;
+        return mShownLayers.contains( layer ) ? Qt::Checked : Qt::Unchecked;
       }
       else
       {
@@ -177,9 +177,10 @@ QVariant Kadas3DLayerTreeModel::data( const QModelIndex &idx, int role ) const
         bool hasChecked = false;
         while ( true )
         {
-          const QVariant v = data( index( n, 0, idx ), role );
-          if ( !v.isValid() )
+          QModelIndex childIdx = index( n, 0, idx );
+          if ( !childIdx.isValid() )
             break;
+          const QVariant v = data( childIdx, role );
 
           switch ( v.value<Qt::CheckState>() )
           {
@@ -214,7 +215,7 @@ bool Kadas3DLayerTreeModel::setData( const QModelIndex &index, const QVariant &v
 {
   if ( index.column() == 0 )
   {
-    if ( role == Qt::CheckStateRole )
+    if ( static_cast<Qt::ItemDataRole>( role ) == Qt::ItemDataRole::CheckStateRole )
     {
       int i = 0;
       for ( i = 0;; i++ )

--- a/kadas/app/3d/kadas3dlayertreemodel.h
+++ b/kadas/app/3d/kadas3dlayertreemodel.h
@@ -32,11 +32,6 @@ class Kadas3DLayerTreeModel : public QSortFilterProxyModel
 
     QgsLayerTreeModel *layerTreeModel() const;
     void setLayerTreeModel( QgsLayerTreeModel *layerTreeModel );
-    void resetLayerTreeModel()
-    {
-      beginResetModel();
-      endResetModel();
-    }
 
     QgsMapLayer *mapLayer( const QModelIndex &idx ) const;
 

--- a/kadas/app/3d/kadas3dmapcanvaswidget.cpp
+++ b/kadas/app/3d/kadas3dmapcanvaswidget.cpp
@@ -293,6 +293,7 @@ Kadas3DMapCanvasWidget::Kadas3DMapCanvasWidget( const QString &name, bool isDock
   mLayerTreeView->setModel( new Kadas3DLayerTreeModel( mCanvas ) );
   mLayerTreeView->setMinimumWidth( 200 );
   mLayerTreeView->setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Expanding );
+  mLayerTreeView->setVisible( sSettingLayerTreeVisible->value() );
 
   QHBoxLayout *hLayout = new QHBoxLayout;
   hLayout->setContentsMargins( 0, 0, 0, 0 );


### PR DESCRIPTION
For 3D canvas, this PR fixes:
- dialog title: "Kadas 3D"
- initial visibility of layer tree view accoring to setting
- behavior of the layer tree: the check state in the legend was incorrect. The original implementation was similar to the snapping in QGIS with partially checked nodes but it was buggy and I am not sure that partially checked nodes are correctly rendered. I went for a simpler approach where only layer nodes are checkable. 