### PR TITLE
Fix 3D chunks are rendered too quickly

### DIFF
--- a/vcpkg/ports/qgis/3dchunkloaderconcurrency.patch
+++ b/vcpkg/ports/qgis/3dchunkloaderconcurrency.patch
@@ -1,0 +1,13 @@
+diff --git a/src/3d/terrain/qgsterraintileloader.cpp b/src/3d/terrain/qgsterraintileloader.cpp
+index 2a48b7c759b..f91658eeb50 100644
+--- a/src/3d/terrain/qgsterraintileloader.cpp
++++ b/src/3d/terrain/qgsterraintileloader.cpp
+@@ -48,7 +48,7 @@ QgsTerrainTileLoader::QgsTerrainTileLoader( QgsTerrainEntity *terrain, QgsChunkN
+ 
+ void QgsTerrainTileLoader::loadTexture()
+ {
+-  connect( mTerrain->textureGenerator(), &QgsTerrainTextureGenerator::tileReady, this, &QgsTerrainTileLoader::onImageReady );
++  connect( mTerrain->textureGenerator(), &QgsTerrainTextureGenerator::tileReady, this, &QgsTerrainTileLoader::onImageReady, Qt::QueuedConnection );
+   mTextureJobId = mTerrain->textureGenerator()->render( mExtentMapCrs, mNode->tileId(), mTileDebugText );
+ }
+ 

--- a/vcpkg/ports/qgis/portfile.cmake
+++ b/vcpkg/ports/qgis/portfile.cmake
@@ -31,6 +31,7 @@ vcpkg_from_github(
   62506.patch # https://jira.swisstopo.ch/browse/MGDIGRE_SB-1262
   sync_2d_3d.patch # https://github.com/qgis/QGIS/pull/62530
   3dfrustumfix.patch
+  3dchunkloaderconcurrency.patch # https://jira.swisstopo.ch/browse/MGDIGRE_SB-1278
 )
 
 file(REMOVE ${SOURCE_PATH}/cmake/FindGDAL.cmake)


### PR DESCRIPTION
This fixes a problem where the rendering results for some chunks (tiles) are not taken into account.

Longer explanation:
`loadTexture()` is called from the constructor of `FlatTerrainChunkLoader`, which is called from `QgsFlatTerrainGenerator::createChunkLoader` (same for DEM, not only Flat). In `QgsChunkedEntity::startJob`, a connection is made to `QgsChunkLoader::finished` which is emited eventually through `onImageReady()` if that texture is loaded very quickly, this is emitted _before_ the connection is made and therefore the job is never finished.
Even worse: we have a maximum of 4 jobs, so if they are all occupied by stalled jobs, no more jobs are done at all.

By using a QueuedConnection, we make sure that the `onImageReady` signal (and the subsequent `finished` signal will be queued and only be sent once we are sure the connection has been made.