### PR TITLE
Don't translate direction suffix 'N', 'E', 'S', 'W'

### DIFF
--- a/kadas/app/kadascanvascontextmenu.cpp
+++ b/kadas/app/kadascanvascontextmenu.cpp
@@ -215,7 +215,7 @@ void KadasCanvasContextMenu::identify()
 void KadasCanvasContextMenu::copyCoordinates()
 {
   const QgsCoordinateReferenceSystem &mapCrs = mCanvas->mapSettings().destinationCrs();
-  QString posStr = KadasCoordinateFormat::instance()->getDisplayString( mMapPos, mapCrs );
+  QString posStr = KadasCoordinateFormat::instance()->getDisplayString( mMapPos, mapCrs, false );
   if ( posStr.isEmpty() )
   {
     posStr = QString( "%1 (%2)" ).arg( mMapPos.toString() ).arg( mapCrs.authid() );

--- a/kadas/core/kadascoordinateformat.cpp
+++ b/kadas/core/kadascoordinateformat.cpp
@@ -72,12 +72,12 @@ const QString &KadasCoordinateFormat::getCoordinateDisplayCrs() const
   return mEpsg;
 }
 
-QString KadasCoordinateFormat::getDisplayString( const QgsPointXY &p, const QgsCoordinateReferenceSystem &sSrs, bool translateDirectionSuffixes = true ) const
+QString KadasCoordinateFormat::getDisplayString( const QgsPointXY &p, const QgsCoordinateReferenceSystem &sSrs, bool translateDirectionSuffixes ) const
 {
   return KadasCoordinateFormat::getDisplayString( p, sSrs, mFormat, mEpsg, translateDirectionSuffixes );
 }
 
-QString KadasCoordinateFormat::getDisplayString( const QgsPointXY &p, const QgsCoordinateReferenceSystem &sSrs, Format format, const QString &epsg, bool translateDirectionSuffixes = true )
+QString KadasCoordinateFormat::getDisplayString( const QgsPointXY &p, const QgsCoordinateReferenceSystem &sSrs, Format format, const QString &epsg, bool translateDirectionSuffixes )
 {
   QgsCoordinateReferenceSystem destCrs( epsg );
   QgsPointXY pTrans;

--- a/kadas/core/kadascoordinateformat.cpp
+++ b/kadas/core/kadascoordinateformat.cpp
@@ -72,12 +72,12 @@ const QString &KadasCoordinateFormat::getCoordinateDisplayCrs() const
   return mEpsg;
 }
 
-QString KadasCoordinateFormat::getDisplayString( const QgsPointXY &p, const QgsCoordinateReferenceSystem &sSrs ) const
+QString KadasCoordinateFormat::getDisplayString( const QgsPointXY &p, const QgsCoordinateReferenceSystem &sSrs, bool translateDirectionSuffixes = true ) const
 {
-  return KadasCoordinateFormat::getDisplayString( p, sSrs, mFormat, mEpsg );
+  return KadasCoordinateFormat::getDisplayString( p, sSrs, mFormat, mEpsg, translateDirectionSuffixes );
 }
 
-QString KadasCoordinateFormat::getDisplayString( const QgsPointXY &p, const QgsCoordinateReferenceSystem &sSrs, Format format, const QString &epsg )
+QString KadasCoordinateFormat::getDisplayString( const QgsPointXY &p, const QgsCoordinateReferenceSystem &sSrs, Format format, const QString &epsg, bool translateDirectionSuffixes = true )
 {
   QgsCoordinateReferenceSystem destCrs( epsg );
   QgsPointXY pTrans;
@@ -98,15 +98,24 @@ QString KadasCoordinateFormat::getDisplayString( const QgsPointXY &p, const QgsC
     }
     case Format::DegMinSec:
     {
-      return QgsCoordinateFormatter::format( pTrans, QgsCoordinateFormatter::FormatDegreesMinutesSeconds, 1 );
+      if ( translateDirectionSuffixes )
+        return QgsCoordinateFormatter::format( pTrans, QgsCoordinateFormatter::FormatDegreesMinutesSeconds, 1 );
+      else
+        return QgsCoordinateFormatter::format( pTrans, QgsCoordinateFormatter::FormatDegreesMinutesSeconds, 1, QgsCoordinateFormatter::FlagDegreesUseUntranslatedStringSuffix );
     }
     case Format::DegMin:
     {
-      return QgsCoordinateFormatter::format( pTrans, QgsCoordinateFormatter::FormatDegreesMinutes, 3 );
+      if ( translateDirectionSuffixes )
+        return QgsCoordinateFormatter::format( pTrans, QgsCoordinateFormatter::FormatDegreesMinutes, 3 );
+      else
+        return QgsCoordinateFormatter::format( pTrans, QgsCoordinateFormatter::FormatDegreesMinutes, 3, QgsCoordinateFormatter::FlagDegreesUseUntranslatedStringSuffix );
     }
     case Format::DecDeg:
     {
-      return QgsCoordinateFormatter::format( pTrans, QgsCoordinateFormatter::FormatDecimalDegrees, 5 );
+      if ( translateDirectionSuffixes )
+        return QgsCoordinateFormatter::format( pTrans, QgsCoordinateFormatter::FormatDecimalDegrees, 5 );
+      else
+        return QgsCoordinateFormatter::format( pTrans, QgsCoordinateFormatter::FormatDecimalDegrees, 5, QgsCoordinateFormatter::FlagDegreesUseUntranslatedStringSuffix );
     }
     case Format::UTM:
     {

--- a/kadas/core/kadascoordinateformat.h
+++ b/kadas/core/kadascoordinateformat.h
@@ -46,8 +46,8 @@ class KADAS_CORE_EXPORT KadasCoordinateFormat : public QObject
     const QString &getCoordinateDisplayCrs() const;
     Qgis::DistanceUnit getHeightDisplayUnit() const { return mHeightUnit; }
 
-    QString getDisplayString( const QgsPointXY &p, const QgsCoordinateReferenceSystem &sSrs ) const;
-    static QString getDisplayString( const QgsPointXY &p, const QgsCoordinateReferenceSystem &sSrs, KadasCoordinateFormat::Format format, const QString &epsg );
+    QString getDisplayString( const QgsPointXY &p, const QgsCoordinateReferenceSystem &sSrs, bool translateDirectionSuffixes = true ) const;
+    static QString getDisplayString( const QgsPointXY &p, const QgsCoordinateReferenceSystem &sSrs, KadasCoordinateFormat::Format format, const QString &epsg, bool translateDirectionSuffixes = true );
 
     double getHeightAtPos( const QgsPointXY &p, const QgsCoordinateReferenceSystem &crs, QString *errMsg = 0 );
 

--- a/python/kadascore/auto_generated/kadascoordinateformat.sip.in
+++ b/python/kadascore/auto_generated/kadascoordinateformat.sip.in
@@ -44,8 +44,8 @@ the Free Software Foundation; either version 2 of the License, or     *
     const QString &getCoordinateDisplayCrs() const;
     Qgis::DistanceUnit getHeightDisplayUnit() const;
 
-    QString getDisplayString( const QgsPointXY &p, const QgsCoordinateReferenceSystem &sSrs ) const;
-    static QString getDisplayString( const QgsPointXY &p, const QgsCoordinateReferenceSystem &sSrs, KadasCoordinateFormat::Format format, const QString &epsg );
+    QString getDisplayString( const QgsPointXY &p, const QgsCoordinateReferenceSystem &sSrs, bool translateDirectionSuffixes = true ) const;
+    static QString getDisplayString( const QgsPointXY &p, const QgsCoordinateReferenceSystem &sSrs, KadasCoordinateFormat::Format format, const QString &epsg, bool translateDirectionSuffixes = true );
 
     double getHeightAtPos( const QgsPointXY &p, const QgsCoordinateReferenceSystem &crs, QString *errMsg = 0 );
 

--- a/vcpkg/ports/qgis/flagDegreesUseUntranslatedStringSuffix.patch
+++ b/vcpkg/ports/qgis/flagDegreesUseUntranslatedStringSuffix.patch
@@ -1,0 +1,88 @@
+diff --git a/src/core/qgscoordinateformatter.cpp b/src/core/qgscoordinateformatter.cpp
+index 27286661fda..4b6dfa4d8a6 100644
+--- a/src/core/qgscoordinateformatter.cpp
++++ b/src/core/qgscoordinateformatter.cpp
+@@ -140,7 +140,10 @@ QString QgsCoordinateFormatter::formatXAsDegreesMinutesSeconds( double val, int
+   QString sign;
+   if ( flags.testFlag( FlagDegreesUseStringSuffix ) )
+   {
+-    hemisphere = wrappedX < 0 ? QObject::tr( "W" ) : QObject::tr( "E" );
++    if ( flags.testFlag( FlagDegreesUseUntranslatedStringSuffix ))
++      hemisphere = wrappedX < 0 ? "W" : "E";
++    else
++      hemisphere = wrappedX < 0 ? QObject::tr( "W" ) : QObject::tr( "E" );
+   }
+   else
+   {
+@@ -222,7 +225,10 @@ QString QgsCoordinateFormatter::formatYAsDegreesMinutesSeconds( double val, int
+   QString sign;
+   if ( flags.testFlag( FlagDegreesUseStringSuffix ) )
+   {
+-    hemisphere = wrappedY < 0 ? QObject::tr( "S" ) : QObject::tr( "N" );
++    if ( flags.testFlag( FlagDegreesUseUntranslatedStringSuffix ))
++      hemisphere = wrappedY < 0 ? "S" : "N";
++    else
++      hemisphere = wrappedY < 0 ? QObject::tr( "S" ) : QObject::tr( "N" );
+   }
+   else
+   {
+@@ -291,7 +297,10 @@ QString QgsCoordinateFormatter::formatXAsDegreesMinutes( double val, int precisi
+   QString sign;
+   if ( flags.testFlag( FlagDegreesUseStringSuffix ) )
+   {
+-    hemisphere = wrappedX < 0 ? QObject::tr( "W" ) : QObject::tr( "E" );
++    if ( flags.testFlag( FlagDegreesUseUntranslatedStringSuffix ))
++      hemisphere = wrappedX < 0 ? "W" : "E";
++    else
++      hemisphere = wrappedX < 0 ? QObject::tr( "W" ) : QObject::tr( "E" );
+   }
+   else
+   {
+@@ -354,7 +363,10 @@ QString QgsCoordinateFormatter::formatYAsDegreesMinutes( double val, int precisi
+   QString sign;
+   if ( flags.testFlag( FlagDegreesUseStringSuffix ) )
+   {
+-    hemisphere = wrappedY < 0 ? QObject::tr( "S" ) : QObject::tr( "N" );
++    if ( flags.testFlag( FlagDegreesUseUntranslatedStringSuffix ))
++      hemisphere = wrappedY < 0 ? "S" : "N";
++    else
++      hemisphere = wrappedY < 0 ? QObject::tr( "S" ) : QObject::tr( "N" );
+   }
+   else
+   {
+@@ -404,7 +416,10 @@ QString QgsCoordinateFormatter::formatXAsDegrees( double val, int precision, For
+   QString sign;
+   if ( flags.testFlag( FlagDegreesUseStringSuffix ) )
+   {
+-    hemisphere = wrappedX < 0 ? QObject::tr( "W" ) : QObject::tr( "E" );
++    if ( flags.testFlag( FlagDegreesUseUntranslatedStringSuffix ))
++      hemisphere = wrappedX < 0 ? "W" : "E";
++    else
++      hemisphere = wrappedX < 0 ? QObject::tr( "W" ) : QObject::tr( "E" );
+   }
+   else
+   {
+@@ -453,7 +468,10 @@ QString QgsCoordinateFormatter::formatYAsDegrees( double val, int precision, For
+   QString sign;
+   if ( flags.testFlag( FlagDegreesUseStringSuffix ) )
+   {
+-    hemisphere = wrappedY < 0 ? QObject::tr( "S" ) : QObject::tr( "N" );
++    if ( flags.testFlag( FlagDegreesUseUntranslatedStringSuffix ))
++      hemisphere = wrappedY < 0 ? "S" : "N";
++    else
++      hemisphere = wrappedY < 0 ? QObject::tr( "S" ) : QObject::tr( "N" );
+   }
+   else
+   {
+diff --git a/src/core/qgscoordinateformatter.h b/src/core/qgscoordinateformatter.h
+index cccf412075e..cbe58387c4e 100644
+--- a/src/core/qgscoordinateformatter.h
++++ b/src/core/qgscoordinateformatter.h
+@@ -58,6 +58,7 @@ class CORE_EXPORT QgsCoordinateFormatter
+     {
+       FlagDegreesUseStringSuffix = 1 << 1, //!< Include a direction suffix (eg 'N', 'E', 'S' or 'W'), otherwise a "-" prefix is used for west and south coordinates
+       FlagDegreesPadMinutesSeconds = 1 << 2, //!< Pad minute and second values with leading zeros, eg '05' instead of '5'
++      FlagDegreesUseUntranslatedStringSuffix = 1 << 3, //!< Don't translate direction suffix. Takes effect only togheter with FlagDegreesUseStringSuffix
+     };
+     Q_DECLARE_FLAGS( FormatFlags, FormatFlag )
+ 

--- a/vcpkg/ports/qgis/portfile.cmake
+++ b/vcpkg/ports/qgis/portfile.cmake
@@ -32,6 +32,7 @@ vcpkg_from_github(
   sync_2d_3d.patch # https://github.com/qgis/QGIS/pull/62530
   3dfrustumfix.patch
   3dchunkloaderconcurrency.patch # https://jira.swisstopo.ch/browse/MGDIGRE_SB-1278
+  flagDegreesUseUntranslatedStringSuffix.patch # https://jira.swisstopo.ch/browse/MGDIGRE_SB-1272
 )
 
 file(REMOVE ${SOURCE_PATH}/cmake/FindGDAL.cmake)


### PR DESCRIPTION
When using the right click menu "Copy coordinates" in the map canvas