### PR TITLE
Close 3D window (or dock) when deactivating

### DIFF
--- a/kadas/app/3d/kadas3dintegration.cpp
+++ b/kadas/app/3d/kadas3dintegration.cpp
@@ -148,7 +148,7 @@ Kadas3DIntegration::Kadas3DIntegration( QAction *action3D, QgsMapCanvas *mapCanv
     }
     else
     {
-      m3DMapCanvasWidget->close();
+      m3DMapCanvasWidget->parentWidget()->close();
     }
   } );
 }


### PR DESCRIPTION
When clicking the 3D ribbon, make sure that the dock (or window) is closed, not just the widget.