### PR TITLE
Detect sip-build path when building with vcpkg

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -90,7 +90,6 @@ jobs:
                 -D INSTALL_DEMO_DATA=ON \
                 -D VCPKG_TARGET_TRIPLET="x64-windows" \
                 -D VCPKG_INSTALL_OPTIONS="--x-buildtrees-root=C:/src" \
-                -D SIP_BUILD_EXECUTABLE="$(pwd)\build\vcpkg_installed\x64-windows\tools\python3\Scripts\sip-build.bat" \
                 -D QGIS_PYTHON_MODULE_DIR="$(pwd)\build\vcpkg_installed\x64-windows\tools\python3\Lib\site-packages\qgis" \
                 -D CPACK_PACKAGE_FILE_NAME="kadas-win64-$(date +'%Y-%m-%d_%H%M')" \
                 -D NUGET_USERNAME=kadas-albireo \

--- a/cmake/FindSIP.cmake
+++ b/cmake/FindSIP.cmake
@@ -51,19 +51,13 @@ else(SIP_VERSION)
     string(REGEX REPLACE ".*\ndefault_sip_dir:([^\n]+).*$" "\\1"
                          SIP_DEFAULT_SIP_DIR ${sip_config}
     )
-    if(${SIP_VERSION_STR} VERSION_LESS 5)
-      string(REGEX REPLACE ".*\nsip_bin:([^\n]+).*$" "\\1" SIP_BINARY_PATH
-                           ${sip_config}
+    if(WITH_VCPKG AND WIN32)
+      set(SIP_BUILD_EXECUTABLE
+          "${VCPKG_BASE_DIR}/${VCPKG_HOST_TRIPLET}/tools/python3/Scripts/sip-build.bat"
       )
-      string(REGEX REPLACE ".*\nsip_inc_dir:([^\n]+).*$" "\\1" SIP_INCLUDE_DIR
-                           ${sip_config}
-      )
-      string(REGEX REPLACE ".*\nsip_module_dir:([^\n]+).*$" "\\1"
-                           SIP_MODULE_DIR ${sip_config}
-      )
-    else(${SIP_VERSION_STR} VERSION_LESS 5)
+    else()
       find_program(SIP_BUILD_EXECUTABLE sip-build)
-    endif(${SIP_VERSION_STR} VERSION_LESS 5)
+    endif()
     set(SIP_FOUND TRUE)
   endif(sip_config)
 


### PR DESCRIPTION
This avoids a common pitfall when getting started with development.