### PR TITLE
Redlining annotation 3d

### DIFF
--- a/kadas/app/kadasapplayerhandling.cpp
+++ b/kadas/app/kadasapplayerhandling.cpp
@@ -43,6 +43,7 @@
 #include <qgis/qgsrasterlayer.h>
 #include <qgis/qgsauthguiutils.h>
 #include <qgis/qgslayerdefinition.h>
+#include <qgis/qgsmapcanvas.h>
 #include <qgis/qgspluginlayer.h>
 #include <qgis/qgspluginlayerregistry.h>
 #include <qgis/qgsprovidersublayersdialog.h>

--- a/kadas/app/kadasapplication.cpp
+++ b/kadas/app/kadasapplication.cpp
@@ -28,8 +28,13 @@
 #include <QUrlQuery>
 #include <quazip/quazipfile.h>
 
+#include <qgis/qgsannotationlineitem.h>
+#include <qgis/qgsannotationpointtextitem.h>
+#include <qgis/qgsannotationpolygonitem.h>
 #include <qgis/qgsauthguiutils.h>
 #include <qgis/qgsauthmanager.h>
+#include <qgis/qgscurve.h>
+#include <qgis/qgscurvepolygon.h>
 #include <qgis/qgsdataitem.h>
 #include <qgis/qgsdatumtransformdialog.h>
 #include <qgis/qgsgdalutils.h>
@@ -1383,8 +1388,15 @@ QgsMapTool *KadasApplication::paste( QgsPointXY *mapPos )
     for ( int i = 0, n = items.size(); i < n; ++i )
     {
       QgsCoordinateTransform crst( mapCrs, items[i]->crs(), QgsProject::instance() );
-      QgsPointXY pos = pastePos + QgsVector( itemPos[i].x() - center.x(), itemPos[i].y() - center.y() );
-      items[i]->setPosition( KadasItemPos::fromPoint( crst.transform( pos ) ) );
+      if ( items[i]->useQgisAnnotations() )
+      {
+        items[i]->translate( pastePos.x() - center.x(), pastePos.y() - center.y() );
+      }
+      else
+      {
+        QgsPointXY pos = pastePos + QgsVector( itemPos[i].x() - center.x(), itemPos[i].y() - center.y() );
+        items[i]->setPosition( KadasItemPos::fromPoint( crst.transform( pos ) ) );
+      }
     }
     KadasItemLayer *layer = kApp->selectPasteTargetItemLayer( items );
     if ( !layer )
@@ -1410,7 +1422,7 @@ QgsMapTool *KadasApplication::paste( QgsPointXY *mapPos )
       if ( feature.geometry().type() == Qgis::GeometryType::Point )
       {
         KadasPointItem *item = new KadasPointItem( featureStore.crs() );
-        item->addPartFromGeometry( *feature.geometry().constGet() );
+        item->setPoint( *qgsgeometry_cast<const QgsPoint *>( feature.geometry().constGet() ) );
         items.append( item );
       }
       else if ( feature.geometry().type() == Qgis::GeometryType::Line )

--- a/kadas/app/kadasgpxintegration.cpp
+++ b/kadas/app/kadasgpxintegration.cpp
@@ -158,7 +158,7 @@ bool KadasGpxIntegration::importGpx( const QString &filename, QString &errorMsg 
 
     KadasGpxWaypointItem *waypoint = new KadasGpxWaypointItem();
     waypoint->setName( name );
-    waypoint->addPartFromGeometry( QgsPoint( lon, lat ) );
+    waypoint->setPoint( QgsPoint( lon, lat ) );
     layer->addItem( waypoint );
   }
   QDomNodeList rtes = doc.elementsByTagName( "rte" );
@@ -270,7 +270,7 @@ void KadasGpxIntegration::saveGpx()
     if ( dynamic_cast<const KadasGpxWaypointItem *>( item ) )
     {
       const KadasGpxWaypointItem *waypoint = static_cast<const KadasGpxWaypointItem *>( item );
-      QgsPoint pt = waypoint->geometry()->vertexAt( QgsVertexId( 0, 0, 0 ) );
+      QgsPoint pt = QgsPoint( waypoint->point() );
       QDomElement wptEl = doc.createElement( "wpt" );
       wptEl.setAttribute( "lon", pt.x() );
       wptEl.setAttribute( "lat", pt.y() );

--- a/kadas/app/kadasredliningintegration.cpp
+++ b/kadas/app/kadasredliningintegration.cpp
@@ -42,7 +42,7 @@
 KadasMapItem *KadasPointItemInterface::createItem() const
 {
   QgsCoordinateReferenceSystem crs = kApp->mainWindow()->mapCanvas()->mapSettings().destinationCrs();
-  KadasMapItem *item = new KadasPointItem( crs, KadasPointItem::IconType::ICON_CIRCLE );
+  KadasMapItem *item = new KadasPointItem( crs, Qgis::MarkerShape::Circle );
   item->setEditor( KadasMapItemEditor::REDLINING_ITEM );
   return item;
 }
@@ -50,7 +50,7 @@ KadasMapItem *KadasPointItemInterface::createItem() const
 KadasMapItem *KadasSquareItemInterface::createItem() const
 {
   QgsCoordinateReferenceSystem crs = kApp->mainWindow()->mapCanvas()->mapSettings().destinationCrs();
-  KadasMapItem *item = new KadasPointItem( crs, KadasPointItem::IconType::ICON_FULL_BOX );
+  KadasMapItem *item = new KadasPointItem( crs, Qgis::MarkerShape::Square );
   item->setEditor( KadasMapItemEditor::REDLINING_ITEM );
   return item;
 };
@@ -58,7 +58,7 @@ KadasMapItem *KadasSquareItemInterface::createItem() const
 KadasMapItem *KadasTriangleItemInterface::createItem() const
 {
   QgsCoordinateReferenceSystem crs = kApp->mainWindow()->mapCanvas()->mapSettings().destinationCrs();
-  KadasMapItem *item = new KadasPointItem( crs, KadasPointItem::IconType::ICON_FULL_TRIANGLE );
+  KadasMapItem *item = new KadasPointItem( crs, Qgis::MarkerShape::Triangle );
   item->setEditor( KadasMapItemEditor::REDLINING_ITEM );
   return item;
 };

--- a/kadas/app/kml/kadaskmlimport.cpp
+++ b/kadas/app/kml/kadaskmlimport.cpp
@@ -202,7 +202,7 @@ bool KadasKMLImport::importDocument( const QString &filename, const QDomDocument
         for ( QgsAbstractGeometry *geom : geoms )
         {
           geom->transform( itemCrst );
-          KadasGeometryItem::IconType iconType = static_cast<KadasGeometryItem::IconType>( attributes.value( "icon_type" ).toInt() );
+          Qgis::MarkerShape iconType = static_cast<Qgis::MarkerShape>( attributes.value( "icon_type" ).toInt() );
           Qt::PenStyle outlineStyle = QgsSymbolLayerUtils::decodePenStyle( attributes.value( "outline_style" ) );
           Qt::BrushStyle fillStyle = QgsSymbolLayerUtils::decodeBrushStyle( attributes.value( "fill_style" ) );
           bool hasZ = false;
@@ -213,7 +213,7 @@ bool KadasKMLImport::importDocument( const QString &filename, const QDomDocument
             KadasTextItem *item = new KadasTextItem( itemLayer->crs() );
             item->setEditor( "KadasRedliningTextEditor" );
             item->setText( name );
-            item->setFillColor( style.labelColor );
+            item->setColor( style.labelColor );
             QFont font = item->font();
             font.setPointSizeF( font.pointSizeF() * style.labelScale );
             item->setFont( font );
@@ -224,11 +224,12 @@ bool KadasKMLImport::importDocument( const QString &filename, const QDomDocument
           {
             KadasPointItem *item = new KadasPointItem( itemLayer->crs() );
             item->setEditor( "KadasRedliningItemEditor" );
-            item->addPartFromGeometry( *geom );
-            item->setIconType( iconType );
+            item->setPoint( *qgsgeometry_cast<const QgsPoint *>( geom ) );
+            item->setShape( iconType );
             item->setIconSize( 10 + 2 * style.outlineSize );
-            item->setIconOutline( QPen( style.outlineColor, style.outlineSize / 4, outlineStyle ) );
-            item->setIconFill( QBrush( style.fillColor, fillStyle ) );
+            item->setStrokeColor( style.outlineColor );
+            item->setStrokeWidth( style.outlineSize / 4 );
+            item->setColor( style.fillColor );
             itemLayer->addItem( item );
           }
           else if ( dynamic_cast<QgsLineString *>( geom ) || dynamic_cast<QgsMultiLineString *>( geom ) )

--- a/kadas/gui/3d/kadasmapitemlayer3drenderer.cpp
+++ b/kadas/gui/3d/kadasmapitemlayer3drenderer.cpp
@@ -1,0 +1,169 @@
+
+
+
+#include <qgis/qgsstyle.h>
+#include <qgis/qgsannotationlayerchunkloader_p.h>
+#include <qgis/qgs3dmapsettings.h>
+
+#include "kadasmapitemlayer3drenderer.h"
+#include "kadas/gui/kadasitemlayer.h"
+
+
+//
+// KadasMapItemLayer3DRendererMetadata
+//
+
+KadasMapItemLayer3DRendererMetadata::KadasMapItemLayer3DRendererMetadata()
+  : Qgs3DRendererAbstractMetadata( QStringLiteral( "mapitem" ) )
+{
+}
+
+QgsAbstract3DRenderer *KadasMapItemLayer3DRendererMetadata::createRenderer( QDomElement &elem, const QgsReadWriteContext &context )
+{
+  auto r = std::make_unique<KadasMapItemLayer3DRenderer>();
+  r->readXml( elem, context );
+  return r.release();
+}
+
+
+//
+// KadasMapItemLayer3DRenderer
+//
+
+KadasMapItemLayer3DRenderer::KadasMapItemLayer3DRenderer()
+{
+  mTextFormat = QgsStyle::defaultStyle()->defaultTextFormat();
+  mTextFormat.setNamedStyle( QStringLiteral( "Bold" ) );
+  mTextFormat.setSize( 20 );
+}
+
+void KadasMapItemLayer3DRenderer::setLayer( KadasItemLayer *layer )
+{
+  mLayerRef.layer = layer;
+}
+
+void KadasMapItemLayer3DRenderer::resolveReferences( const QgsProject &project )
+{
+  mLayerRef.resolve( &project );
+}
+
+bool KadasMapItemLayer3DRenderer::showCalloutLines() const
+{
+  return mShowCalloutLines;
+}
+
+void KadasMapItemLayer3DRenderer::setShowCalloutLines( bool show )
+{
+  mShowCalloutLines = show;
+}
+
+void KadasMapItemLayer3DRenderer::setCalloutLineColor( const QColor &color )
+{
+  mCalloutLineColor = color;
+}
+
+QColor KadasMapItemLayer3DRenderer::calloutLineColor() const
+{
+  return mCalloutLineColor;
+}
+
+void KadasMapItemLayer3DRenderer::setCalloutLineWidth( double width )
+{
+  mCalloutLineWidth = width;
+}
+
+double KadasMapItemLayer3DRenderer::calloutLineWidth() const
+{
+  return mCalloutLineWidth;
+}
+
+QgsTextFormat KadasMapItemLayer3DRenderer::textFormat() const
+{
+  return mTextFormat;
+}
+
+void KadasMapItemLayer3DRenderer::setTextFormat( const QgsTextFormat &format )
+{
+  mTextFormat = format;
+}
+
+QString KadasMapItemLayer3DRenderer::type() const
+{
+  return "annotation";
+}
+
+KadasMapItemLayer3DRenderer *KadasMapItemLayer3DRenderer::clone() const
+{
+  auto r = std::make_unique<KadasMapItemLayer3DRenderer>();
+  r->mLayerRef = mLayerRef;
+  r->mAltClamping = mAltClamping;
+  r->mZOffset = mZOffset;
+  r->mShowCalloutLines = mShowCalloutLines;
+  r->mCalloutLineColor = mCalloutLineColor;
+  r->mCalloutLineWidth = mCalloutLineWidth;
+  r->mTextFormat = mTextFormat;
+  return r.release();
+}
+
+Qt3DCore::QEntity *KadasMapItemLayer3DRenderer::createEntity( Qgs3DMapSettings *map ) const
+{
+  KadasItemLayer *itemLayer = qobject_cast<KadasItemLayer *>( mLayerRef.layer );
+
+  if ( !itemLayer )
+    return nullptr;
+
+  QgsAnnotationLayer *annotationLayer = itemLayer->qgisAnnotationLayer( map->crs() );
+
+  // For some cases we start with a maximal z range because we can't know this upfront, as it potentially involves terrain heights.
+  // This range will be refined after populating the nodes to the actual z range of the generated chunks nodes.
+  // Assuming the vertical height is in meter, then it's extremely unlikely that a real vertical
+  // height will exceed this amount!
+  constexpr double MINIMUM_ANNOTATION_Z_ESTIMATE = -100000;
+  constexpr double MAXIMUM_ANNOTATION_Z_ESTIMATE = 100000;
+
+  double minimumZ = MINIMUM_ANNOTATION_Z_ESTIMATE;
+  double maximumZ = MAXIMUM_ANNOTATION_Z_ESTIMATE;
+  switch ( mAltClamping )
+  {
+    case Qgis::AltitudeClamping::Absolute:
+      // special case where we DO know the exact z range upfront!
+      minimumZ = mZOffset;
+      maximumZ = mZOffset;
+      break;
+
+    case Qgis::AltitudeClamping::Relative:
+    case Qgis::AltitudeClamping::Terrain:
+      break;
+  }
+
+  return new QgsAnnotationLayerChunkedEntity( map, annotationLayer, mAltClamping, mZOffset, mShowCalloutLines, mCalloutLineColor, mCalloutLineWidth, mTextFormat, minimumZ, maximumZ );
+}
+
+void KadasMapItemLayer3DRenderer::writeXml( QDomElement &elem, const QgsReadWriteContext &context ) const
+{
+  QDomDocument doc = elem.ownerDocument();
+
+  elem.setAttribute( QStringLiteral( "layer" ), mLayerRef.layerId );
+  elem.setAttribute( QStringLiteral( "clamping" ), qgsEnumValueToKey( mAltClamping ) );
+  elem.setAttribute( QStringLiteral( "offset" ), mZOffset );
+  if ( mShowCalloutLines )
+    elem.setAttribute( QStringLiteral( "callouts" ), QStringLiteral( "1" ) );
+
+  if ( mTextFormat.isValid() )
+  {
+    elem.appendChild( mTextFormat.writeXml( doc, context ) );
+  }
+}
+
+void KadasMapItemLayer3DRenderer::readXml( const QDomElement &elem, const QgsReadWriteContext &context )
+{
+  mLayerRef = QgsMapLayerRef( elem.attribute( QStringLiteral( "layer" ) ) );
+  mAltClamping = qgsEnumKeyToValue( elem.attribute( QStringLiteral( "clamping" ) ), Qgis::AltitudeClamping::Relative );
+  mZOffset = elem.attribute( QStringLiteral( "offset" ), QString::number( DEFAULT_Z_OFFSET ) ).toDouble();
+  mShowCalloutLines = elem.attribute( QStringLiteral( "callouts" ), QStringLiteral( "0" ) ).toInt();
+  if ( !elem.firstChildElement( QStringLiteral( "text-style" ) ).isNull() )
+  {
+    mTextFormat = QgsTextFormat();
+    mTextFormat.readXml( elem.firstChildElement( QStringLiteral( "text-style" ) ), context );
+  }
+}

--- a/kadas/gui/3d/kadasmapitemlayer3drenderer.h
+++ b/kadas/gui/3d/kadasmapitemlayer3drenderer.h
@@ -1,0 +1,179 @@
+#ifndef KADASMAPITEMLAYER3DRENDERER_H
+#define KADASMAPITEMLAYER3DRENDERER_H
+
+
+#include <qgis/qgs3drendererregistry.h>
+#include <qgis/qgsabstract3drenderer.h>
+#include <qgis/qgstextformat.h>
+#include <qgis/qgsmaplayerref.h>
+
+#include "kadas/gui/kadas_gui.h"
+
+class KadasItemLayer;
+
+
+#ifdef SIP_RUN
+// this is needed for the "convert to subclass" code below to compile
+% ModuleHeaderCode
+#include "kadas/gui/3d/kadasmapitemlayer3drenderer.h"
+  % End
+#endif
+
+
+  // This code has been copied from QgsAnnotationLayer3DRenderer
+
+  /**
+ * \ingroup core
+ * \brief Metadata for annotation layer 3D renderer to allow creation of its instances from XML.
+ *
+ * \warning This is not considered stable API, and may change in future QGIS releases. It is
+ * exposed to the Python bindings as a tech preview only.
+ *
+ * \since QGIS 4.0
+ */
+  class KADAS_GUI_EXPORT KadasMapItemLayer3DRendererMetadata : public Qgs3DRendererAbstractMetadata
+{
+  public:
+    KadasMapItemLayer3DRendererMetadata();
+
+    //! Creates an instance of a 3D renderer based on a DOM element with renderer configuration
+    QgsAbstract3DRenderer *createRenderer( QDomElement &elem, const QgsReadWriteContext &context ) override SIP_FACTORY;
+};
+
+/**
+ * \ingroup qgis_3d
+ * \brief 3D renderers for annotation layers.
+ *
+ * \since QGIS 4.0
+ */
+class KADAS_GUI_EXPORT KadasMapItemLayer3DRenderer : public QgsAbstract3DRenderer
+{
+#ifdef SIP_RUN
+    SIP_CONVERT_TO_SUBCLASS_CODE
+    if ( dynamic_cast<KadasMapItemLayer3DRenderer *>( sipCpp ) != nullptr )
+      sipType = sipType_KadasMapItemLayer3DRenderer;
+    else
+      sipType = nullptr;
+    SIP_END
+#endif
+
+  public:
+    KadasMapItemLayer3DRenderer();
+
+    void setLayer( KadasItemLayer *layer );
+
+
+    QString type() const override;
+    KadasMapItemLayer3DRenderer *clone() const override SIP_FACTORY;
+    Qt3DCore::QEntity *createEntity( Qgs3DMapSettings *map ) const override SIP_SKIP;
+
+    void writeXml( QDomElement &elem, const QgsReadWriteContext &context ) const override;
+    void readXml( const QDomElement &elem, const QgsReadWriteContext &context ) override;
+    void resolveReferences( const QgsProject &project ) override;
+
+    /**
+     * Returns the altitude clamping method, which determines the vertical position of annotations.
+     *
+     * \see setAltitudeClamping()
+     */
+    Qgis::AltitudeClamping altitudeClamping() const { return mAltClamping; }
+
+    /**
+     * Sets the altitude \a clamping method, which determines the vertical position of annotations.
+     *
+     * \see altitudeClamping()
+     */
+    void setAltitudeClamping( Qgis::AltitudeClamping clamping ) { mAltClamping = clamping; }
+
+    /**
+     * Returns the z offset, which is a fixed offset amount which should be added to z values for the annotations.
+     *
+     * \see setZOffset()
+     */
+    double zOffset() const { return mZOffset; }
+
+    /**
+     * Sets the z \a offset, which is a fixed offset amount which will be added to z values for the annotations.
+     *
+     * \see zOffset()
+     */
+    void setZOffset( double offset ) { mZOffset = offset; }
+
+    /**
+     * Returns TRUE if callout lines are shown, vertically joining the annotations to the terrain.
+     *
+     * \see setShowCalloutLines()
+     */
+    bool showCalloutLines() const;
+
+    /**
+     * Sets whether callout lines are shown, vertically joining the annotations to the terrain.
+     *
+     * \see showCalloutLines()
+     */
+    void setShowCalloutLines( bool show );
+
+    // TODO -- consider exposing via QgsSimpleLineMaterialSettings, for now, for testing only
+    /**
+     * Sets the callout line \a color.
+     *
+     * \see calloutLineColor()
+     * \note Not available in Python bindings
+     */
+    SIP_SKIP void setCalloutLineColor( const QColor &color );
+
+    /**
+     * Returns the callout line color.
+     *
+     * \see setCalloutLineColor()
+     * \note Not available in Python bindings
+     */
+    SIP_SKIP QColor calloutLineColor() const;
+
+    /**
+     * Sets the callout line \a width.
+     *
+     * \see calloutLineWidth()
+     * \note Not available in Python bindings
+     */
+    SIP_SKIP void setCalloutLineWidth( double width );
+
+    /**
+     * Returns the callout line width.
+     *
+     * \see setCalloutLineWidth()
+     * \note Not available in Python bindings
+     */
+    SIP_SKIP double calloutLineWidth() const;
+
+    /**
+     * Returns the text format to use for rendering text annotations in 3D.
+     *
+     * \see setTextFormat()
+     */
+    QgsTextFormat textFormat() const;
+
+    /**
+     * Sets the text \a format to use for rendering text annotations in 3D.
+     *
+     * \see textFormat()
+     */
+    void setTextFormat( const QgsTextFormat &format );
+
+  private:
+#ifdef SIP_RUN
+    KadasMapItemLayer3DRenderer( const KadasMapItemLayer3DRenderer & );
+#endif
+
+    static constexpr double DEFAULT_Z_OFFSET = 50;
+
+    QgsMapLayerRef mLayerRef;
+    Qgis::AltitudeClamping mAltClamping = Qgis::AltitudeClamping::Relative;
+    double mZOffset = DEFAULT_Z_OFFSET;
+    bool mShowCalloutLines = true;
+    QColor mCalloutLineColor { 0, 0, 0 };
+    double mCalloutLineWidth = 2;
+    QgsTextFormat mTextFormat;
+};
+
+#endif // KADASMAPITEMLAYER3DRENDERER

--- a/kadas/gui/CMakeLists.txt
+++ b/kadas/gui/CMakeLists.txt
@@ -23,6 +23,7 @@ set(kadas_gui_SRC
     kadasribbonbutton.cpp
     kadasrichtexteditor.cpp
     kadastextbrowser.cpp
+    3d/kadasmapitemlayer3drenderer.cpp
     maptools/kadasmaptoolcreateitem.cpp
     maptools/kadasmaptooldeleteitems.cpp
     maptools/kadasmaptooledititem.cpp
@@ -104,6 +105,7 @@ set(kadas_gui_HDR
     kadasrichtexteditor.h
     kadassearchprovider.h
     kadastextbrowser.h
+    3d/kadasmapitemlayer3drenderer.h
     maptools/kadasmaptoolcreateitem.h
     maptools/kadasmaptooldeleteitems.h
     maptools/kadasmaptooledititem.h
@@ -185,6 +187,7 @@ target_link_libraries(
   Qt5::Concurrent
   QuaZip::QuaZip
   QGIS::Gui
+  QGIS::3D
   ${GeographicLib_LIBRARIES}
   PkgConfig::LIBRSVG
   PkgConfig::SVG2SVGT

--- a/kadas/gui/kadasitemcontextmenuactions.cpp
+++ b/kadas/gui/kadasitemcontextmenuactions.cpp
@@ -19,6 +19,7 @@
 #include <QInputDialog>
 #include <QMenu>
 
+#include <qgis/qgsannotationmarkeritem.h>
 #include <qgis/qgsapplication.h>
 #include <qgis/qgslinestring.h>
 #include <qgis/qgsmapcanvas.h>
@@ -119,7 +120,7 @@ void KadasItemContextMenuActions::createWaypointFromPin()
   KadasGpxWaypointItem *waypoint = new KadasGpxWaypointItem();
   waypoint->setName( pin->name() );
   QgsCoordinateTransform crst( pin->crs(), waypoint->crs(), QgsProject::instance()->transformContext() );
-  waypoint->setPosition( KadasItemPos::fromPoint( crst.transform( pin->position() ) ) );
+  waypoint->setPoint( QgsPoint( crst.transform( pin->position() ) ) );
   KadasItemLayerRegistry::getOrCreateItemLayer( KadasItemLayerRegistry::StandardLayer::RoutesLayer )->addItem( waypoint );
 
   KadasItemLayerRegistry::getOrCreateItemLayer( KadasItemLayerRegistry::StandardLayer::RoutesLayer )->triggerRepaint();

--- a/kadas/gui/kadasitemlayer.h
+++ b/kadas/gui/kadasitemlayer.h
@@ -25,6 +25,7 @@
 
 class QMenu;
 class QuaZip;
+class QgsAnnotationLayer;
 class KadasMapItem;
 class KadasMapPos;
 
@@ -141,6 +142,12 @@ class KADAS_GUI_EXPORT KadasItemLayer : public KadasPluginLayer
       PICK_OBJECTIVE_ANY,
       PICK_OBJECTIVE_TOOLTIP
     };
+
+    //! Create and return a QGIS annotation layer
+    //! In the future, Kadas would use only annotation layers
+    //! Until the migration is complete we can dynamically create annotation layers for specific use-cases such as 3D rendering
+    //! The QGIS annotation layer will only contain items/annotations inheriting from QgsAnnotationItem.
+    QgsAnnotationLayer *qgisAnnotationLayer( const QgsCoordinateReferenceSystem &crs ) const SIP_FACTORY;
 
     static QString layerType() { return "KadasItemLayer"; }
     KadasItemLayer( const QString &name, const QgsCoordinateReferenceSystem &crs );

--- a/kadas/gui/kadasprojectmigration.cpp
+++ b/kadas/gui/kadasprojectmigration.cpp
@@ -169,11 +169,11 @@ void KadasProjectMigration::migrateKadas1xTo2x( QDomDocument &doc, QDomElement &
         KadasTextItem *textItem = new KadasTextItem( crs );
         textItem->setText( redliningItemEl.attribute( "text" ) );
         textItem->setPosition( KadasItemPos::fromPoint( point ) );
-        textItem->setAngle( flags["rotation"].toDouble() );
-        textItem->setOutlineColor( outline );
-        textItem->setFillColor( fill );
-        textItem->state()->mRectangleCenterPoint.setX( 0 );
-        textItem->state()->mRectangleCenterPoint.setY( 1. );
+        //textItem->setAngle( flags["rotation"].toDouble() );
+        //textItem->setOutlineColor( outline );
+        textItem->setColor( fill );
+        // textItem->state()->mRectangleCenterPoint.setX( 0 );
+        // textItem->state()->mRectangleCenterPoint.setY( 1. );
 
         QFont font;
         font.setBold( flags["bold"].toInt() != 0 );
@@ -188,114 +188,126 @@ void KadasProjectMigration::migrateKadas1xTo2x( QDomDocument &doc, QDomElement &
       }
       else
       {
-        KadasGeometryItem *geomItem = nullptr;
-        QgsAbstractGeometry *geom = nullptr;
-
         if ( flags["shape"] == "point" )
         {
-          geom = new QgsPoint();
-          geom->fromWkt( redliningItemEl.attribute( "geometry" ) );
+          KadasPointItem *pointItem = nullptr;
+          const QgsPointXY point = QgsGeometry::fromWkt( redliningItemEl.attribute( "geometry" ) ).asPoint();
 
           if ( isGps )
           {
-            geomItem = new KadasGpxWaypointItem();
-            static_cast<KadasGpxWaypointItem *>( geomItem )->setName( redliningItemEl.attribute( "text" ) );
+            pointItem = new KadasGpxWaypointItem();
+            static_cast<KadasGpxWaypointItem *>( pointItem )->setName( redliningItemEl.attribute( "text" ) );
           }
           else
           {
-            KadasPointItem::IconType iconType = KadasPointItem::IconType::ICON_CIRCLE;
+            Qgis::MarkerShape iconType = Qgis::MarkerShape::Circle;
             if ( flags["symbol"] == "circle" )
             {
-              iconType = KadasPointItem::IconType::ICON_CIRCLE;
+              iconType = Qgis::MarkerShape::Circle;
             }
             else if ( flags["symbol"] == "rectangle" )
             {
-              iconType = KadasPointItem::IconType::ICON_FULL_BOX;
+              iconType = Qgis::MarkerShape::Square;
             }
             else if ( flags["symbol"] == "triangle" )
             {
-              iconType = KadasPointItem::IconType::ICON_FULL_TRIANGLE;
+              iconType = Qgis::MarkerShape::Triangle;
             }
 
-            geomItem = new KadasPointItem( crs, iconType );
+            pointItem = new KadasPointItem( crs, iconType );
+            pointItem->setEditor( "KadasRedliningItemEditor" );
+          }
+
+          pointItem->setPoint( QgsPoint( point ) );
+
+          pointItem->setIconSize( 8 * redliningItemEl.attribute( "size" ).toInt() );
+          pointItem->setColor( QgsSymbolLayerUtils::decodeColor( redliningItemEl.attribute( "fill" ) ) );
+          pointItem->setStrokeColor( QgsSymbolLayerUtils::decodeColor( redliningItemEl.attribute( "outline" ) ) );
+          pointItem->setStrokeWidth( redliningItemEl.attribute( "size" ).toInt() );
+
+          item = pointItem;
+        }
+        else
+        {
+          QgsAbstractGeometry *geom = nullptr;
+
+          KadasGeometryItem *geomItem = nullptr;
+          if ( flags["shape"] == "line" )
+          {
+            geom = new QgsLineString();
+            geom->fromWkt( redliningItemEl.attribute( "geometry" ) );
+            if ( isGps )
+            {
+              geomItem = new KadasGpxRouteItem();
+              static_cast<KadasGpxRouteItem *>( geomItem )->setName( redliningItemEl.attribute( "text" ) );
+              static_cast<KadasGpxRouteItem *>( geomItem )->setNumber( flags["routeNumber"] );
+            }
+            else
+            {
+              geomItem = new KadasLineItem( crs );
+              geomItem->setEditor( "KadasRedliningItemEditor" );
+            }
+          }
+          else if ( flags["shape"] == "polygon" )
+          {
+            geom = new QgsPolygon();
+            geom->fromWkt( redliningItemEl.attribute( "geometry" ) );
+
+            geomItem = new KadasPolygonItem( crs );
             geomItem->setEditor( "KadasRedliningItemEditor" );
           }
-        }
-        else if ( flags["shape"] == "line" )
-        {
-          geom = new QgsLineString();
-          geom->fromWkt( redliningItemEl.attribute( "geometry" ) );
-          if ( isGps )
+          else if ( flags["shape"] == "rectangle" )
           {
-            geomItem = new KadasGpxRouteItem();
-            static_cast<KadasGpxRouteItem *>( geomItem )->setName( redliningItemEl.attribute( "text" ) );
-            static_cast<KadasGpxRouteItem *>( geomItem )->setNumber( flags["routeNumber"] );
-          }
-          else
-          {
-            geomItem = new KadasLineItem( crs );
+            geom = new QgsPolygon();
+            geom->fromWkt( redliningItemEl.attribute( "geometry" ) );
+
+            geomItem = new KadasRectangleItem( crs );
             geomItem->setEditor( "KadasRedliningItemEditor" );
           }
-        }
-        else if ( flags["shape"] == "polygon" )
-        {
-          geom = new QgsPolygon();
-          geom->fromWkt( redliningItemEl.attribute( "geometry" ) );
-
-          geomItem = new KadasPolygonItem( crs );
-          geomItem->setEditor( "KadasRedliningItemEditor" );
-        }
-        else if ( flags["shape"] == "rectangle" )
-        {
-          geom = new QgsPolygon();
-          geom->fromWkt( redliningItemEl.attribute( "geometry" ) );
-
-          geomItem = new KadasRectangleItem( crs );
-          geomItem->setEditor( "KadasRedliningItemEditor" );
-        }
-        else if ( flags["shape"] == "circle" )
-        {
-          // Circular strings were incorrectly serialized to wkt as ringpoint - center - ringpoint instead of 3x ringpoint
-          QgsCurvePolygon curve;
-          curve.fromWkt( redliningItemEl.attribute( "geometry" ) );
-          QgsPointSequence points;
-          curve.exteriorRing()->points( points );
-          if ( points.size() == 3 )
+          else if ( flags["shape"] == "circle" )
           {
-            points[1].setX( points[1].x() - points[0].distance( points[1] ) );
+            // Circular strings were incorrectly serialized to wkt as ringpoint - center - ringpoint instead of 3x ringpoint
+            QgsCurvePolygon curve;
+            curve.fromWkt( redliningItemEl.attribute( "geometry" ) );
+            QgsPointSequence points;
+            curve.exteriorRing()->points( points );
+            if ( points.size() == 3 )
+            {
+              points[1].setX( points[1].x() - points[0].distance( points[1] ) );
+            }
+
+            QgsCircularString *ring = new QgsCircularString();
+            ring->setPoints( points );
+            geom = new QgsCurvePolygon();
+            static_cast<QgsCurvePolygon *>( geom )->setExteriorRing( ring );
+
+            geomItem = new KadasCircleItem( crs );
+            geomItem->setEditor( "KadasRedliningItemEditor" );
           }
 
-          QgsCircularString *ring = new QgsCircularString();
-          ring->setPoints( points );
-          geom = new QgsCurvePolygon();
-          static_cast<QgsCurvePolygon *>( geom )->setExteriorRing( ring );
+          if ( geomItem && geom )
+          {
+            geomItem->addPartFromGeometry( *geom );
 
-          geomItem = new KadasCircleItem( crs );
-          geomItem->setEditor( "KadasRedliningItemEditor" );
+            QBrush brush;
+            brush.setColor( QgsSymbolLayerUtils::decodeColor( redliningItemEl.attribute( "fill" ) ) );
+            brush.setStyle( QgsSymbolLayerUtils::decodeBrushStyle( redliningItemEl.attribute( "fill_style" ) ) );
+            geomItem->setFill( brush );
+
+            QPen pen;
+            pen.setColor( QgsSymbolLayerUtils::decodeColor( redliningItemEl.attribute( "outline" ) ) );
+            pen.setStyle( QgsSymbolLayerUtils::decodePenStyle( redliningItemEl.attribute( "outline_style" ) ) );
+            pen.setWidth( redliningItemEl.attribute( "size" ).toInt() );
+            geomItem->setOutline( pen );
+
+            geomItem->setIconSize( 8 * pen.width() );
+            geomItem->setIconFill( brush );
+            geomItem->setIconOutline( QPen( pen.color(), pen.width(), pen.style() ) );
+
+            item = geomItem;
+          }
+          delete geom;
         }
-
-        if ( geomItem && geom )
-        {
-          geomItem->addPartFromGeometry( *geom );
-
-          QBrush brush;
-          brush.setColor( QgsSymbolLayerUtils::decodeColor( redliningItemEl.attribute( "fill" ) ) );
-          brush.setStyle( QgsSymbolLayerUtils::decodeBrushStyle( redliningItemEl.attribute( "fill_style" ) ) );
-          geomItem->setFill( brush );
-
-          QPen pen;
-          pen.setColor( QgsSymbolLayerUtils::decodeColor( redliningItemEl.attribute( "outline" ) ) );
-          pen.setStyle( QgsSymbolLayerUtils::decodePenStyle( redliningItemEl.attribute( "outline_style" ) ) );
-          pen.setWidth( redliningItemEl.attribute( "size" ).toInt() );
-          geomItem->setOutline( pen );
-
-          geomItem->setIconSize( 8 * pen.width() );
-          geomItem->setIconFill( brush );
-          geomItem->setIconOutline( QPen( pen.color(), pen.width(), pen.style() ) );
-
-          item = geomItem;
-        }
-        delete geom;
       }
       if ( !item )
       {
@@ -304,7 +316,7 @@ void KadasProjectMigration::migrateKadas1xTo2x( QDomDocument &doc, QDomElement &
 
       QDomElement mapItemEl = doc.createElement( "MapItem" );
       mapItemEl.setAttribute( "name", item->metaObject()->className() );
-      mapItemEl.setAttribute( "crs", item->authId() );
+      mapItemEl.setAttribute( "crs", item->crs().authid() );
       QJsonDocument jsonDoc;
       jsonDoc.setObject( item->serialize() );
       mapItemEl.appendChild( doc.createCDATASection( jsonDoc.toJson( QJsonDocument::Compact ) ) );

--- a/kadas/gui/mapitemeditors/kadasgpxwaypointeditor.cpp
+++ b/kadas/gui/mapitemeditors/kadasgpxwaypointeditor.cpp
@@ -70,11 +70,11 @@ void KadasGpxWaypointEditor::syncItemToWidget()
   }
 
   mUi.mSpinBoxSize->blockSignals( true );
-  mUi.mSpinBoxSize->setValue( waypointItem->outline().width() );
+  mUi.mSpinBoxSize->setValue( waypointItem->strokeWidth() );
   mUi.mSpinBoxSize->blockSignals( false );
 
   mUi.mToolButtonColor->blockSignals( true );
-  mUi.mToolButtonColor->setColor( waypointItem->fill().color() );
+  mUi.mToolButtonColor->setColor( waypointItem->color() );
   mUi.mToolButtonColor->blockSignals( false );
 
   mUi.mLineEditName->blockSignals( true );
@@ -115,12 +115,10 @@ void KadasGpxWaypointEditor::syncWidgetToItem()
   int size = mUi.mSpinBoxSize->value();
   QColor color = mUi.mToolButtonColor->color();
 
-  waypointItem->setOutline( QPen( color, size ) );
-  waypointItem->setFill( QBrush( color ) );
-
+  waypointItem->setColor( color );
+  waypointItem->setStrokeWidth( size );
+  waypointItem->setStrokeColor( color );
   waypointItem->setIconSize( 10 + 2 * size );
-  waypointItem->setIconOutline( QPen( Qt::black, size / 2 ) );
-  waypointItem->setIconFill( QBrush( color ) );
 
   waypointItem->setName( mUi.mLineEditName->text() );
 

--- a/kadas/gui/mapitemeditors/kadasredliningitemeditor.cpp
+++ b/kadas/gui/mapitemeditors/kadasredliningitemeditor.cpp
@@ -18,6 +18,7 @@
 #include <qgis/qgssymbollayerutils.h>
 
 #include "kadas/gui/mapitems/kadasgeometryitem.h"
+#include "kadas/gui/mapitems/kadaspointitem.h"
 #include "kadas/gui/mapitemeditors/kadasredliningitemeditor.h"
 
 
@@ -43,11 +44,11 @@ KadasRedliningItemEditor::KadasRedliningItemEditor( KadasMapItem *item )
   connect( mUi.mToolButtonBorderColor, &QgsColorButton::colorChanged, this, &KadasRedliningItemEditor::saveColor );
 
   mUi.mComboBoxOutlineStyle->setProperty( "settings_key", "outline_style" );
-  mUi.mComboBoxOutlineStyle->addItem( createOutlineStyleIcon( Qt::NoPen ), QString(), static_cast<int>( Qt::NoPen ) );
-  mUi.mComboBoxOutlineStyle->addItem( createOutlineStyleIcon( Qt::SolidLine ), QString(), static_cast<int>( Qt::SolidLine ) );
-  mUi.mComboBoxOutlineStyle->addItem( createOutlineStyleIcon( Qt::DashLine ), QString(), static_cast<int>( Qt::DashLine ) );
-  mUi.mComboBoxOutlineStyle->addItem( createOutlineStyleIcon( Qt::DashDotLine ), QString(), static_cast<int>( Qt::DashDotLine ) );
-  mUi.mComboBoxOutlineStyle->addItem( createOutlineStyleIcon( Qt::DotLine ), QString(), static_cast<int>( Qt::DotLine ) );
+  mUi.mComboBoxOutlineStyle->addItem( createOutlineStyleIcon( Qt::NoPen ), QString(), QVariant::fromValue( Qt::NoPen ) );
+  mUi.mComboBoxOutlineStyle->addItem( createOutlineStyleIcon( Qt::SolidLine ), QString(), QVariant::fromValue( Qt::SolidLine ) );
+  mUi.mComboBoxOutlineStyle->addItem( createOutlineStyleIcon( Qt::DashLine ), QString(), QVariant::fromValue( Qt::DashLine ) );
+  mUi.mComboBoxOutlineStyle->addItem( createOutlineStyleIcon( Qt::DashDotLine ), QString(), QVariant::fromValue( Qt::DashDotLine ) );
+  mUi.mComboBoxOutlineStyle->addItem( createOutlineStyleIcon( Qt::DotLine ), QString(), QVariant::fromValue( Qt::DotLine ) );
   mUi.mComboBoxOutlineStyle->setCurrentIndex( QgsSettings().value( "/Redlining/outline_style", "1" ).toInt() );
   connect( mUi.mComboBoxOutlineStyle, qOverload<int>( &QComboBox::currentIndexChanged ), this, &KadasRedliningItemEditor::saveStyle );
 
@@ -59,15 +60,15 @@ KadasRedliningItemEditor::KadasRedliningItemEditor( KadasMapItem *item )
   connect( mUi.mToolButtonFillColor, &QgsColorButton::colorChanged, this, &KadasRedliningItemEditor::saveColor );
 
   mUi.mComboBoxFillStyle->setProperty( "settings_key", "fill_style" );
-  mUi.mComboBoxFillStyle->addItem( createFillStyleIcon( Qt::NoBrush ), QString(), static_cast<int>( Qt::NoBrush ) );
-  mUi.mComboBoxFillStyle->addItem( createFillStyleIcon( Qt::SolidPattern ), QString(), static_cast<int>( Qt::SolidPattern ) );
-  mUi.mComboBoxFillStyle->addItem( createFillStyleIcon( Qt::HorPattern ), QString(), static_cast<int>( Qt::HorPattern ) );
-  mUi.mComboBoxFillStyle->addItem( createFillStyleIcon( Qt::VerPattern ), QString(), static_cast<int>( Qt::VerPattern ) );
-  mUi.mComboBoxFillStyle->addItem( createFillStyleIcon( Qt::BDiagPattern ), QString(), static_cast<int>( Qt::BDiagPattern ) );
-  mUi.mComboBoxFillStyle->addItem( createFillStyleIcon( Qt::DiagCrossPattern ), QString(), static_cast<int>( Qt::DiagCrossPattern ) );
-  mUi.mComboBoxFillStyle->addItem( createFillStyleIcon( Qt::FDiagPattern ), QString(), static_cast<int>( Qt::FDiagPattern ) );
-  mUi.mComboBoxFillStyle->addItem( createFillStyleIcon( Qt::CrossPattern ), QString(), static_cast<int>( Qt::CrossPattern ) );
-  mUi.mComboBoxFillStyle->setCurrentIndex( QgsSettings().value( "/Redlining/fill_style", "1" ).toInt() );
+  mUi.mComboBoxFillStyle->addItem( createFillStyleIcon( Qt::NoBrush ), QString(), QVariant::fromValue( Qt::NoBrush ) );
+  mUi.mComboBoxFillStyle->addItem( createFillStyleIcon( Qt::SolidPattern ), QString(), QVariant::fromValue( Qt::SolidPattern ) );
+  mUi.mComboBoxFillStyle->addItem( createFillStyleIcon( Qt::HorPattern ), QString(), QVariant::fromValue( Qt::HorPattern ) );
+  mUi.mComboBoxFillStyle->addItem( createFillStyleIcon( Qt::VerPattern ), QString(), QVariant::fromValue( Qt::VerPattern ) );
+  mUi.mComboBoxFillStyle->addItem( createFillStyleIcon( Qt::BDiagPattern ), QString(), QVariant::fromValue( Qt::BDiagPattern ) );
+  mUi.mComboBoxFillStyle->addItem( createFillStyleIcon( Qt::DiagCrossPattern ), QString(), QVariant::fromValue( Qt::DiagCrossPattern ) );
+  mUi.mComboBoxFillStyle->addItem( createFillStyleIcon( Qt::FDiagPattern ), QString(), QVariant::fromValue( Qt::FDiagPattern ) );
+  mUi.mComboBoxFillStyle->addItem( createFillStyleIcon( Qt::CrossPattern ), QString(), QVariant::fromValue( Qt::CrossPattern ) );
+  mUi.mComboBoxFillStyle->setCurrentIndex( QgsSettings().value( "/Redlining/fill_style", 1 ).toInt() );
   connect( mUi.mComboBoxFillStyle, qOverload<int>( &QComboBox::currentIndexChanged ), this, &KadasRedliningItemEditor::saveStyle );
 
   if ( geometryItem && geometryItem->geometryType() == Qgis::GeometryType::Line )
@@ -91,57 +92,90 @@ void KadasRedliningItemEditor::setItem( KadasMapItem *item )
 
 void KadasRedliningItemEditor::syncItemToWidget()
 {
-  KadasGeometryItem *geometryItem = dynamic_cast<KadasGeometryItem *>( mItem );
-  if ( !geometryItem )
+  if ( KadasPointItem *pointItem = dynamic_cast<KadasPointItem *>( mItem ) )
   {
-    return;
+    mUi.mSpinBoxSize->blockSignals( true );
+    mUi.mSpinBoxSize->setValue( pointItem->iconSize() );
+    mUi.mSpinBoxSize->blockSignals( false );
+
+    mUi.mToolButtonBorderColor->blockSignals( true );
+    mUi.mToolButtonBorderColor->setColor( pointItem->strokeColor() );
+    mUi.mToolButtonBorderColor->blockSignals( false );
+
+    mUi.mToolButtonFillColor->blockSignals( true );
+    mUi.mToolButtonFillColor->setColor( pointItem->color() );
+    mUi.mToolButtonFillColor->blockSignals( false );
+
+    mUi.mComboBoxOutlineStyle->blockSignals( true );
+    mUi.mComboBoxOutlineStyle->setCurrentIndex( mUi.mComboBoxOutlineStyle->findData( QVariant::fromValue( pointItem->strokeStyle() ) ) );
+    mUi.mComboBoxOutlineStyle->blockSignals( false );
+
+    //   mUi.mComboBoxFillStyle->blockSignals( true );
+    //   mUi.mComboBoxFillStyle->setCurrentIndex( mUi.mComboBoxFillStyle->findData( QVariant::fromValue( pointItem->fill().style() ) ) );
+    //   mUi.mComboBoxFillStyle->blockSignals( false );
   }
+  else if ( KadasGeometryItem *geometryItem = dynamic_cast<KadasGeometryItem *>( mItem ) )
+  {
+    mUi.mSpinBoxSize->blockSignals( true );
+    mUi.mSpinBoxSize->setValue( geometryItem->outline().width() );
+    mUi.mSpinBoxSize->blockSignals( false );
 
-  mUi.mSpinBoxSize->blockSignals( true );
-  mUi.mSpinBoxSize->setValue( geometryItem->outline().width() );
-  mUi.mSpinBoxSize->blockSignals( false );
+    mUi.mToolButtonBorderColor->blockSignals( true );
+    mUi.mToolButtonBorderColor->setColor( geometryItem->outline().color() );
+    mUi.mToolButtonBorderColor->blockSignals( false );
 
-  mUi.mToolButtonBorderColor->blockSignals( true );
-  mUi.mToolButtonBorderColor->setColor( geometryItem->outline().color() );
-  mUi.mToolButtonBorderColor->blockSignals( false );
+    mUi.mToolButtonFillColor->blockSignals( true );
+    mUi.mToolButtonFillColor->setColor( geometryItem->fill().color() );
+    mUi.mToolButtonFillColor->blockSignals( false );
 
-  mUi.mToolButtonFillColor->blockSignals( true );
-  mUi.mToolButtonFillColor->setColor( geometryItem->fill().color() );
-  mUi.mToolButtonFillColor->blockSignals( false );
+    mUi.mComboBoxOutlineStyle->blockSignals( true );
+    mUi.mComboBoxOutlineStyle->setCurrentIndex( mUi.mComboBoxOutlineStyle->findData( QVariant::fromValue( geometryItem->outline().style() ) ) );
+    mUi.mComboBoxOutlineStyle->blockSignals( false );
 
-  mUi.mComboBoxOutlineStyle->blockSignals( true );
-  mUi.mComboBoxOutlineStyle->setCurrentIndex( mUi.mComboBoxOutlineStyle->findData( static_cast<int>( geometryItem->outline().style() ) ) );
-  mUi.mComboBoxOutlineStyle->blockSignals( false );
-
-  mUi.mComboBoxFillStyle->blockSignals( true );
-  mUi.mComboBoxFillStyle->setCurrentIndex( mUi.mComboBoxFillStyle->findData( static_cast<int>( geometryItem->fill().style() ) ) );
-  mUi.mComboBoxFillStyle->blockSignals( false );
+    mUi.mComboBoxFillStyle->blockSignals( true );
+    mUi.mComboBoxFillStyle->setCurrentIndex( mUi.mComboBoxFillStyle->findData( QVariant::fromValue( geometryItem->fill().style() ) ) );
+    mUi.mComboBoxFillStyle->blockSignals( false );
+  }
 }
 
 void KadasRedliningItemEditor::syncWidgetToItem()
 {
-  KadasGeometryItem *geometryItem = dynamic_cast<KadasGeometryItem *>( mItem );
-  if ( !geometryItem )
+  if ( KadasPointItem *pointItem = dynamic_cast<KadasPointItem *>( mItem ) )
   {
-    return;
+    int size = mUi.mSpinBoxSize->value();
+    QColor outlineColor = mUi.mToolButtonBorderColor->color();
+    QColor fillColor = mUi.mToolButtonFillColor->color();
+    Qt::PenStyle lineStyle = mUi.mComboBoxOutlineStyle->currentData().value<Qt::PenStyle>();
+    //Qt::BrushStyle brushStyle = static_cast<Qt::BrushStyle>( mUi.mComboBoxFillStyle->itemData( mUi.mComboBoxFillStyle->currentIndex() ).toInt() );
+
+    pointItem->blockSignals( true );
+    pointItem->setColor( fillColor );
+    pointItem->setStrokeColor( outlineColor );
+    pointItem->setStrokeStyle( lineStyle );
+    pointItem->setIconSize( size );
+    pointItem->blockSignals( false );
+    emit pointItem->changed();
+    emit pointItem->propertyChanged();
   }
+  else if ( KadasGeometryItem *geometryItem = dynamic_cast<KadasGeometryItem *>( mItem ) )
+  {
+    int outlineWidth = mUi.mSpinBoxSize->value();
+    QColor outlineColor = mUi.mToolButtonBorderColor->color();
+    QColor fillColor = mUi.mToolButtonFillColor->color();
+    Qt::PenStyle lineStyle = mUi.mComboBoxOutlineStyle->currentData().value<Qt::PenStyle>();
+    Qt::BrushStyle brushStyle = static_cast<Qt::BrushStyle>( mUi.mComboBoxFillStyle->itemData( mUi.mComboBoxFillStyle->currentIndex() ).toInt() );
 
-  int outlineWidth = mUi.mSpinBoxSize->value();
-  QColor outlineColor = mUi.mToolButtonBorderColor->color();
-  QColor fillColor = mUi.mToolButtonFillColor->color();
-  Qt::PenStyle lineStyle = static_cast<Qt::PenStyle>( mUi.mComboBoxOutlineStyle->itemData( mUi.mComboBoxOutlineStyle->currentIndex() ).toInt() );
-  Qt::BrushStyle brushStyle = static_cast<Qt::BrushStyle>( mUi.mComboBoxFillStyle->itemData( mUi.mComboBoxFillStyle->currentIndex() ).toInt() );
+    geometryItem->blockSignals( true );
+    geometryItem->setOutline( QPen( outlineColor, outlineWidth, lineStyle ) );
+    geometryItem->setFill( QBrush( fillColor, brushStyle ) );
 
-  geometryItem->blockSignals( true );
-  geometryItem->setOutline( QPen( outlineColor, outlineWidth, lineStyle ) );
-  geometryItem->setFill( QBrush( fillColor, brushStyle ) );
-
-  geometryItem->setIconSize( 10 + 2 * outlineWidth );
-  geometryItem->setIconOutline( QPen( outlineColor, outlineWidth / 4, lineStyle ) );
-  geometryItem->setIconFill( QBrush( fillColor, brushStyle ) );
-  geometryItem->blockSignals( false );
-  emit geometryItem->changed();
-  emit geometryItem->propertyChanged();
+    geometryItem->setIconSize( 10 + 2 * outlineWidth );
+    geometryItem->setIconOutline( QPen( outlineColor, outlineWidth / 4, lineStyle ) );
+    geometryItem->setIconFill( QBrush( fillColor, brushStyle ) );
+    geometryItem->blockSignals( false );
+    emit geometryItem->changed();
+    emit geometryItem->propertyChanged();
+  }
 }
 
 KadasRedliningItemEditor::~KadasRedliningItemEditor()

--- a/kadas/gui/mapitemeditors/kadasredliningtexteditor.cpp
+++ b/kadas/gui/mapitemeditors/kadasredliningtexteditor.cpp
@@ -46,16 +46,10 @@ KadasRedliningTextEditor::KadasRedliningTextEditor( KadasMapItem *item )
   mUi.mPushButtonItalic->setChecked( font.italic() );
   connect( mUi.mPushButtonItalic, &QPushButton::toggled, this, &KadasRedliningTextEditor::saveFont );
 
-  mUi.mToolButtonBorderColor->setAllowOpacity( true );
-  mUi.mToolButtonBorderColor->setShowNoColor( true );
-  QColor initialOutlineColor = QgsSymbolLayerUtils::decodeColor( QgsSettings().value( "/Redlining/text_outline_color", "255,255,255,255" ).toString() );
-  mUi.mToolButtonBorderColor->setColor( initialOutlineColor );
-  connect( mUi.mToolButtonBorderColor, &QgsColorButton::colorChanged, this, &KadasRedliningTextEditor::saveOutlineColor );
-
-  mUi.mToolButtonFillColor->setAllowOpacity( true );
+  mUi.mToolButtonColor->setAllowOpacity( true );
   QColor initialFillColor = QgsSymbolLayerUtils::decodeColor( QgsSettings().value( "/Redlining/text_color", "0,0,0,255" ).toString() );
-  mUi.mToolButtonFillColor->setColor( initialFillColor );
-  connect( mUi.mToolButtonFillColor, &QgsColorButton::colorChanged, this, &KadasRedliningTextEditor::saveFillColor );
+  mUi.mToolButtonColor->setColor( initialFillColor );
+  connect( mUi.mToolButtonColor, &QgsColorButton::colorChanged, this, &KadasRedliningTextEditor::saveColor );
 
   KadasTextItem *textItem = dynamic_cast<KadasTextItem *>( mItem );
   if ( !textItem )
@@ -77,13 +71,9 @@ void KadasRedliningTextEditor::syncItemToWidget()
   mUi.mLineEditText->setText( textItem->text() );
   mUi.mLineEditText->blockSignals( false );
 
-  mUi.mToolButtonBorderColor->blockSignals( true );
-  mUi.mToolButtonBorderColor->setColor( textItem->outlineColor() );
-  mUi.mToolButtonBorderColor->blockSignals( false );
-
-  mUi.mToolButtonFillColor->blockSignals( true );
-  mUi.mToolButtonFillColor->setColor( textItem->fillColor() );
-  mUi.mToolButtonFillColor->blockSignals( false );
+  mUi.mToolButtonColor->blockSignals( true );
+  mUi.mToolButtonColor->setColor( textItem->color() );
+  mUi.mToolButtonColor->blockSignals( false );
 
   mUi.mFontComboBox->blockSignals( true );
   QFont fontFamily;
@@ -115,8 +105,7 @@ void KadasRedliningTextEditor::syncWidgetToItem()
   disconnect( mItemConnection );
 
   textItem->setText( mUi.mLineEditText->text() );
-  textItem->setOutlineColor( mUi.mToolButtonBorderColor->color() );
-  textItem->setFillColor( mUi.mToolButtonFillColor->color() );
+  textItem->setColor( mUi.mToolButtonColor->color() );
   textItem->setFont( currentFont() );
 
   mItemConnection = connect( textItem, &KadasTextItem::propertyChanged, this, &KadasRedliningTextEditor::syncItemToWidget );
@@ -145,28 +134,16 @@ QFont KadasRedliningTextEditor::currentFont() const
   return font;
 }
 
-void KadasRedliningTextEditor::saveFillColor()
+void KadasRedliningTextEditor::saveColor()
 {
-  QgsSettings().setValue( "text_color", QgsSymbolLayerUtils::encodeColor( mUi.mToolButtonFillColor->color() ) );
+  QgsSettings().setValue( "/Redlining/text_color", QgsSymbolLayerUtils::encodeColor( mUi.mToolButtonColor->color() ) );
 
   KadasTextItem *textItem = dynamic_cast<KadasTextItem *>( mItem );
   if ( !textItem )
   {
     return;
   }
-  textItem->setFillColor( mUi.mToolButtonFillColor->color() );
-}
-
-void KadasRedliningTextEditor::saveOutlineColor()
-{
-  QgsSettings().setValue( "text_outline_color", QgsSymbolLayerUtils::encodeColor( mUi.mToolButtonBorderColor->color() ) );
-
-  KadasTextItem *textItem = dynamic_cast<KadasTextItem *>( mItem );
-  if ( !textItem )
-  {
-    return;
-  }
-  textItem->setOutlineColor( mUi.mToolButtonBorderColor->color() );
+  textItem->setColor( mUi.mToolButtonColor->color() );
 }
 
 void KadasRedliningTextEditor::saveFont()

--- a/kadas/gui/mapitemeditors/kadasredliningtexteditor.h
+++ b/kadas/gui/mapitemeditors/kadasredliningtexteditor.h
@@ -42,8 +42,7 @@ class KADAS_GUI_EXPORT KadasRedliningTextEditor : public KadasMapItemEditor
     QFont currentFont() const;
 
   private slots:
-    void saveFillColor();
-    void saveOutlineColor();
+    void saveColor();
     void saveFont();
     void saveText();
 };

--- a/kadas/gui/mapitemeditors/kadassymbolattributeseditor.cpp
+++ b/kadas/gui/mapitemeditors/kadassymbolattributeseditor.cpp
@@ -44,7 +44,7 @@ KadasSymbolAttributesEditor::KadasSymbolAttributesEditor( KadasMapItem *item )
 
 void KadasSymbolAttributesEditor::adjustVisiblity()
 {
-  setEnabled( mItem && mItem->constState()->drawStatus != KadasMapItem::State::DrawStatus::Empty );
+  setEnabled( mItem && mItem->drawStatus() != KadasMapItem::DrawStatus::Empty );
 }
 
 void KadasSymbolAttributesEditor::setItem( KadasMapItem *item )

--- a/kadas/gui/mapitems/kadasanchoreditem.cpp
+++ b/kadas/gui/mapitems/kadasanchoreditem.cpp
@@ -35,7 +35,7 @@ QJsonObject KadasAnchoredItem::State::serialize() const
   s.append( size.height() );
 
   QJsonObject json;
-  json["status"] = static_cast<int>( drawStatus );
+  //json["status"] = static_cast<int>( drawStatus );
   ;
   json["pos"] = p;
   json["angle"] = angle;
@@ -45,7 +45,7 @@ QJsonObject KadasAnchoredItem::State::serialize() const
 
 bool KadasAnchoredItem::State::deserialize( const QJsonObject &json )
 {
-  drawStatus = static_cast<DrawStatus>( json["status"].toInt() );
+  //drawStatus = static_cast<DrawStatus>( json["status"].toInt() );
   QJsonArray p = json["pos"].toArray();
   pos = KadasItemPos( p.at( 0 ).toDouble(), p.at( 1 ).toDouble() );
   angle = json["angle"].toDouble();
@@ -79,7 +79,7 @@ void KadasAnchoredItem::setAnchorY( double anchorY )
 void KadasAnchoredItem::setPosition( const KadasItemPos &pos )
 {
   state()->pos = pos;
-  state()->drawStatus = State::DrawStatus::Finished;
+  mDrawStatus = DrawStatus::Finished;
   update();
 }
 
@@ -89,9 +89,9 @@ void KadasAnchoredItem::setAngle( double angle )
   update();
 }
 
-KadasItemRect KadasAnchoredItem::boundingBox() const
+QgsRectangle KadasAnchoredItem::boundingBox() const
 {
-  return KadasItemRect( constState()->pos, constState()->pos );
+  return QgsRectangle( constState()->pos, constState()->pos );
 }
 
 QList<KadasMapPos> KadasAnchoredItem::rotatedCornerPoints( double angle, const QgsMapSettings &settings ) const
@@ -139,7 +139,7 @@ KadasMapItem::Margin KadasAnchoredItem::margin() const
 QList<KadasMapItem::Node> KadasAnchoredItem::nodes( const QgsMapSettings &settings ) const
 {
   QList<Node> nodes;
-  if ( constState()->drawStatus == State::DrawStatus::Empty )
+  if ( mDrawStatus == DrawStatus::Empty )
   {
     return nodes;
   }
@@ -153,7 +153,7 @@ QList<KadasMapItem::Node> KadasAnchoredItem::nodes( const QgsMapSettings &settin
   return nodes;
 }
 
-bool KadasAnchoredItem::intersects( const KadasMapRect &rect, const QgsMapSettings &settings, bool contains ) const
+bool KadasAnchoredItem::intersects( const QgsRectangle &rect, const QgsMapSettings &settings, bool contains ) const
 {
   if ( constState()->size.isEmpty() )
   {
@@ -177,7 +177,7 @@ bool KadasAnchoredItem::intersects( const KadasMapRect &rect, const QgsMapSettin
 
 bool KadasAnchoredItem::startPart( const KadasMapPos &firstPoint, const QgsMapSettings &mapSettings )
 {
-  state()->drawStatus = State::DrawStatus::Drawing;
+  mDrawStatus = DrawStatus::Drawing;
   state()->pos = toItemPos( firstPoint, mapSettings );
   update();
   return false;
@@ -206,7 +206,7 @@ bool KadasAnchoredItem::continuePart( const QgsMapSettings &mapSettings )
 
 void KadasAnchoredItem::endPart()
 {
-  state()->drawStatus = State::DrawStatus::Finished;
+  mDrawStatus = DrawStatus::Finished;
 }
 
 KadasMapItem::AttribDefs KadasAnchoredItem::drawAttribs() const

--- a/kadas/gui/mapitems/kadasanchoreditem.h
+++ b/kadas/gui/mapitems/kadasanchoreditem.h
@@ -35,10 +35,10 @@ class KADAS_GUI_EXPORT KadasAnchoredItem : public KadasMapItem SIP_ABSTRACT
     double anchorY() const { return mAnchorY; }
     void setAnchorY( double anchorY );
 
-    KadasItemRect boundingBox() const override;
+    QgsRectangle boundingBox() const override;
     Margin margin() const override;
     QList<KadasMapItem::Node> nodes( const QgsMapSettings &settings ) const override;
-    bool intersects( const KadasMapRect &rect, const QgsMapSettings &settings, bool contains = false ) const override;
+    bool intersects( const QgsRectangle &rect, const QgsMapSettings &settings, bool contains = false ) const override;
 
     bool startPart( const KadasMapPos &firstPoint, const QgsMapSettings &mapSettings ) override;
     bool startPart( const AttribValues &values, const QgsMapSettings &mapSettings ) override;

--- a/kadas/gui/mapitems/kadascircleitem.cpp
+++ b/kadas/gui/mapitems/kadascircleitem.cpp
@@ -47,7 +47,7 @@ QJsonObject KadasCircleItem::State::serialize() const
     r.append( p );
   }
   QJsonObject json;
-  json["status"] = static_cast<int>( drawStatus );
+  //json["status"] = static_cast<int>( drawStatus );
   ;
   json["centers"] = c;
   json["ringpos"] = r;
@@ -59,7 +59,7 @@ bool KadasCircleItem::State::deserialize( const QJsonObject &json )
   centers.clear();
   ringpos.clear();
 
-  drawStatus = static_cast<DrawStatus>( json["status"].toInt() );
+  //drawStatus = static_cast<DrawStatus>( json["status"].toInt() );
   for ( QJsonValue val : json["centers"].toArray() )
   {
     QJsonArray pos = val.toArray();
@@ -131,7 +131,7 @@ QList<KadasMapItem::Node> KadasCircleItem::nodes( const QgsMapSettings &settings
 
 bool KadasCircleItem::startPart( const KadasMapPos &firstPoint, const QgsMapSettings &mapSettings )
 {
-  state()->drawStatus = State::DrawStatus::Drawing;
+  mDrawStatus = DrawStatus::Drawing;
   state()->centers.append( toItemPos( firstPoint, mapSettings ) );
   state()->ringpos.append( toItemPos( firstPoint, mapSettings ) );
   recomputeDerived();
@@ -167,7 +167,7 @@ bool KadasCircleItem::continuePart( const QgsMapSettings &mapSettings )
 
 void KadasCircleItem::endPart()
 {
-  state()->drawStatus = State::DrawStatus::Finished;
+  mDrawStatus = DrawStatus::Finished;
 }
 
 KadasMapItem::AttribDefs KadasCircleItem::drawAttribs() const
@@ -182,7 +182,7 @@ KadasMapItem::AttribDefs KadasCircleItem::drawAttribs() const
 KadasMapItem::AttribValues KadasCircleItem::drawAttribsFromPosition( const KadasMapPos &pos, const QgsMapSettings &mapSettings ) const
 {
   AttribValues values;
-  if ( constState()->drawStatus == State::DrawStatus::Drawing )
+  if ( mDrawStatus == DrawStatus::Drawing )
   {
     KadasMapPos mapCenter = toMapPos( constState()->centers.last(), mapSettings );
     KadasItemPos itemRingPos = toItemPos( pos, mapSettings );
@@ -344,6 +344,13 @@ void KadasCircleItem::addPartFromGeometry( const QgsAbstractGeometry &geom )
 const QgsMultiSurface *KadasCircleItem::geometry() const
 {
   return static_cast<QgsMultiSurface *>( mGeometry );
+}
+
+KadasMapItem *KadasCircleItem::_clone() const
+{
+  KadasCircleItem *item = new KadasCircleItem( crs() );
+  item->mGeometry = mGeometry->clone();
+  return item;
 }
 
 QgsMultiSurface *KadasCircleItem::geometry()

--- a/kadas/gui/mapitems/kadascircleitem.h
+++ b/kadas/gui/mapitems/kadascircleitem.h
@@ -75,7 +75,7 @@ class KADAS_GUI_EXPORT KadasCircleItem : public KadasGeometryItem
     const State *constState() const { return static_cast<State *>( mState ); }
 
   protected:
-    KadasMapItem *_clone() const override SIP_FACTORY { return new KadasCircleItem( crs() ); }
+    KadasMapItem *_clone() const override SIP_FACTORY;
     State *createEmptyState() const override SIP_FACTORY { return new State(); }
     void recomputeDerived() override;
     void measureGeometry() override;

--- a/kadas/gui/mapitems/kadascircularsectoritem.cpp
+++ b/kadas/gui/mapitems/kadascircularsectoritem.cpp
@@ -81,7 +81,7 @@ QJsonObject KadasCircularSectorItem::State::serialize() const
     a2.append( stopAngle );
   }
   QJsonObject json;
-  json["status"] = static_cast<int>( drawStatus );
+  //json["status"] = static_cast<int>( drawStatus );
   json["centers"] = c;
   json["radii"] = r;
   json["startAngles"] = a1;
@@ -97,7 +97,7 @@ bool KadasCircularSectorItem::State::deserialize( const QJsonObject &json )
   startAngles.clear();
   stopAngles.clear();
 
-  drawStatus = static_cast<DrawStatus>( json["status"].toInt() );
+  //drawStatus = static_cast<DrawStatus>( json["status"].toInt() );
   for ( QJsonValue val : json["centers"].toArray() )
   {
     QJsonArray pos = val.toArray();
@@ -167,7 +167,7 @@ QList<KadasMapItem::Node> KadasCircularSectorItem::nodes( const QgsMapSettings &
 
 bool KadasCircularSectorItem::startPart( const KadasMapPos &firstPoint, const QgsMapSettings &mapSettings )
 {
-  state()->drawStatus = State::DrawStatus::Drawing;
+  mDrawStatus = DrawStatus::Drawing;
   state()->sectorStatus = State::SectorStatus::HaveCenter;
   state()->centers.append( toItemPos( firstPoint, mapSettings ) );
   state()->radii.append( 0 );
@@ -181,7 +181,7 @@ bool KadasCircularSectorItem::startPart( const AttribValues &values, const QgsMa
 {
   KadasItemPos center = toItemPos( KadasMapPos( values[AttrX], values[AttrY] ), mapSettings );
   KadasItemPos rPos = toItemPos( KadasMapPos( values[AttrX] + values[AttrR], values[AttrY] ), mapSettings );
-  state()->drawStatus = State::DrawStatus::Drawing;
+  mDrawStatus = DrawStatus::Drawing;
   state()->sectorStatus = values[AttrR] > 0 ? State::SectorStatus::HaveRadius : State::SectorStatus::HaveCenter;
   state()->centers.append( center );
   state()->radii.append( std::sqrt( center.sqrDist( rPos ) ) );
@@ -261,7 +261,7 @@ bool KadasCircularSectorItem::continuePart( const QgsMapSettings &mapSettings )
 
 void KadasCircularSectorItem::endPart()
 {
-  state()->drawStatus = State::DrawStatus::Finished;
+  mDrawStatus = DrawStatus::Finished;
 }
 
 KadasMapItem::AttribDefs KadasCircularSectorItem::drawAttribs() const
@@ -278,7 +278,7 @@ KadasMapItem::AttribDefs KadasCircularSectorItem::drawAttribs() const
 KadasMapItem::AttribValues KadasCircularSectorItem::drawAttribsFromPosition( const KadasMapPos &pos, const QgsMapSettings &mapSettings ) const
 {
   AttribValues attributes;
-  if ( constState()->drawStatus == State::DrawStatus::Empty )
+  if ( mDrawStatus == DrawStatus::Empty )
   {
     attributes.insert( AttrX, pos.x() );
     attributes.insert( AttrY, pos.y() );
@@ -350,6 +350,13 @@ void KadasCircularSectorItem::addPartFromGeometry( const QgsAbstractGeometry &ge
 const QgsMultiSurface *KadasCircularSectorItem::geometry() const
 {
   return static_cast<QgsMultiSurface *>( mGeometry );
+}
+
+KadasMapItem *KadasCircularSectorItem::_clone() const
+{
+  KadasCircularSectorItem *item = new KadasCircularSectorItem( crs() );
+  item->mGeometry = mGeometry->clone();
+  return item;
 }
 
 QgsMultiSurface *KadasCircularSectorItem::geometry()

--- a/kadas/gui/mapitems/kadascircularsectoritem.h
+++ b/kadas/gui/mapitems/kadascircularsectoritem.h
@@ -80,7 +80,7 @@ class KADAS_GUI_EXPORT KadasCircularSectorItem : public KadasGeometryItem
     const State *constState() const { return static_cast<State *>( mState ); }
 
   protected:
-    KadasMapItem *_clone() const override SIP_FACTORY { return new KadasCircularSectorItem( crs() ); }
+    KadasMapItem *_clone() const override SIP_FACTORY;
     State *createEmptyState() const override SIP_FACTORY { return new State(); }
     void recomputeDerived() override;
     void measureGeometry() override;

--- a/kadas/gui/mapitems/kadascoordinatecrossitem.cpp
+++ b/kadas/gui/mapitems/kadascoordinatecrossitem.cpp
@@ -29,7 +29,7 @@
 QJsonObject KadasCoordinateCrossItem::State::serialize() const
 {
   QJsonObject json;
-  json["status"] = static_cast<int>( drawStatus );
+  //json["status"] = static_cast<int>( drawStatus );
   ;
   json["x"] = pos.x();
   json["y"] = pos.y();
@@ -38,7 +38,7 @@ QJsonObject KadasCoordinateCrossItem::State::serialize() const
 
 bool KadasCoordinateCrossItem::State::deserialize( const QJsonObject &json )
 {
-  drawStatus = static_cast<DrawStatus>( json["status"].toInt() );
+  //drawStatus = static_cast<DrawStatus>( json["status"].toInt() );
   pos.setX( json["x"].toDouble() );
   pos.setY( json["y"].toDouble() );
   return true;
@@ -50,9 +50,9 @@ KadasCoordinateCrossItem::KadasCoordinateCrossItem( const QgsCoordinateReference
   clear();
 }
 
-KadasItemRect KadasCoordinateCrossItem::boundingBox() const
+QgsRectangle KadasCoordinateCrossItem::boundingBox() const
 {
-  return KadasItemRect( constState()->pos.x(), constState()->pos.y(), constState()->pos.x(), constState()->pos.y() );
+  return QgsRectangle( constState()->pos.x(), constState()->pos.y(), constState()->pos.x(), constState()->pos.y() );
 }
 
 KadasMapItem::Margin KadasCoordinateCrossItem::margin() const
@@ -65,7 +65,7 @@ QList<KadasMapItem::Node> KadasCoordinateCrossItem::nodes( const QgsMapSettings 
   return { { toMapPos( constState()->pos, settings ) } };
 }
 
-bool KadasCoordinateCrossItem::intersects( const KadasMapRect &rect, const QgsMapSettings &settings, bool contains ) const
+bool KadasCoordinateCrossItem::intersects( const QgsRectangle &rect, const QgsMapSettings &settings, bool contains ) const
 {
   double mapCrossSize = sCrossSize * settings.mapUnitsPerPixel();
   KadasMapPos itemMapPos = toMapPos( constState()->pos, settings );
@@ -156,7 +156,7 @@ void KadasCoordinateCrossItem::setPosition( const KadasItemPos &pos )
 
 bool KadasCoordinateCrossItem::startPart( const KadasMapPos &firstPoint, const QgsMapSettings &mapSettings )
 {
-  state()->drawStatus = State::DrawStatus::Drawing;
+  mDrawStatus = DrawStatus::Drawing;
   state()->pos = roundToKilometre( toItemPos( firstPoint, mapSettings ) );
   update();
   return false;
@@ -186,7 +186,7 @@ bool KadasCoordinateCrossItem::continuePart( const QgsMapSettings &mapSettings )
 
 void KadasCoordinateCrossItem::endPart()
 {
-  state()->drawStatus = State::DrawStatus::Finished;
+  mDrawStatus = DrawStatus::Finished;
 }
 
 KadasMapItem::AttribDefs KadasCoordinateCrossItem::drawAttribs() const

--- a/kadas/gui/mapitems/kadascoordinatecrossitem.h
+++ b/kadas/gui/mapitems/kadascoordinatecrossitem.h
@@ -28,10 +28,10 @@ class KADAS_GUI_EXPORT KadasCoordinateCrossItem : public KadasMapItem
 
     QString itemName() const override { return tr( "Coordinate cross" ); }
 
-    KadasItemRect boundingBox() const override;
+    QgsRectangle boundingBox() const override;
     Margin margin() const override;
     QList<KadasMapItem::Node> nodes( const QgsMapSettings &settings ) const override;
-    bool intersects( const KadasMapRect &rect, const QgsMapSettings &settings, bool contains = false ) const override;
+    bool intersects( const QgsRectangle &rect, const QgsMapSettings &settings, bool contains = false ) const override;
     void render( QgsRenderContext &context ) const override;
 #ifndef SIP_RUN
     QString asKml( const QgsRenderContext &context, QuaZip *kmzZip = nullptr ) const override;

--- a/kadas/gui/mapitems/kadasgeometryitem.cpp
+++ b/kadas/gui/mapitems/kadasgeometryitem.cpp
@@ -269,7 +269,7 @@ void KadasGeometryItem::setInternalGeometry( QgsAbstractGeometry *geom )
   emit geometryChanged();
 }
 
-bool KadasGeometryItem::intersects( const KadasMapRect &rect, const QgsMapSettings &settings, bool contains ) const
+bool KadasGeometryItem::intersects( const QgsRectangle &rect, const QgsMapSettings &settings, bool contains ) const
 {
   if ( !mGeometry )
   {
@@ -379,10 +379,10 @@ void KadasGeometryItem::setIconFill( const QBrush &iconBrush )
   emit propertyChanged();
 }
 
-KadasItemRect KadasGeometryItem::boundingBox() const
+QgsRectangle KadasGeometryItem::boundingBox() const
 {
   QgsRectangle bbox = mGeometry ? mGeometry->boundingBox() : QgsRectangle();
-  return KadasItemRect( bbox.xMinimum(), bbox.yMinimum(), bbox.xMaximum(), bbox.yMaximum() );
+  return bbox;
 }
 
 QList<KadasMapItem::Node> KadasGeometryItem::nodes( const QgsMapSettings &settings ) const

--- a/kadas/gui/mapitems/kadasgeometryitem.h
+++ b/kadas/gui/mapitems/kadasgeometryitem.h
@@ -77,10 +77,10 @@ class KADAS_GUI_EXPORT KadasGeometryItem : public KadasMapItem SIP_ABSTRACT
     KadasGeometryItem( const QgsCoordinateReferenceSystem &crs );
     ~KadasGeometryItem();
 
-    KadasItemRect boundingBox() const override;
+    QgsRectangle boundingBox() const override;
     Margin margin() const override;
     QList<KadasMapItem::Node> nodes( const QgsMapSettings &settings ) const override;
-    bool intersects( const KadasMapRect &rect, const QgsMapSettings &settings, bool contains = false ) const override;
+    bool intersects( const QgsRectangle &rect, const QgsMapSettings &settings, bool contains = false ) const override;
     QPair<KadasMapPos, double> closestPoint( const KadasMapPos &pos, const QgsMapSettings &settings ) const override;
     void render( QgsRenderContext &context ) const override;
 #ifndef SIP_RUN

--- a/kadas/gui/mapitems/kadaslineitem.cpp
+++ b/kadas/gui/mapitems/kadaslineitem.cpp
@@ -47,14 +47,14 @@ QJsonObject KadasLineItem::State::serialize() const
     pts.append( prt );
   }
   QJsonObject json;
-  json["status"] = static_cast<int>( drawStatus );
+  //json["status"] = static_cast<int>( drawStatus );
   json["points"] = pts;
   return json;
 }
 
 bool KadasLineItem::State::deserialize( const QJsonObject &json )
 {
-  drawStatus = static_cast<DrawStatus>( json["status"].toInt() );
+  //drawStatus = static_cast<DrawStatus>( json["status"].toInt() );
   points.clear();
   QJsonArray pts = json["points"].toArray();
   for ( QJsonValue prtValue : pts )
@@ -138,7 +138,7 @@ QList<KadasMapItem::Node> KadasLineItem::nodes( const QgsMapSettings &settings )
 bool KadasLineItem::startPart( const KadasMapPos &firstPoint, const QgsMapSettings &mapSettings )
 {
   KadasItemPos itemPos = toItemPos( firstPoint, mapSettings );
-  state()->drawStatus = State::DrawStatus::Drawing;
+  mDrawStatus = DrawStatus::Drawing;
   state()->points.append( QList<KadasItemPos>() );
   state()->points.last().append( itemPos );
   state()->points.last().append( itemPos );
@@ -180,7 +180,7 @@ bool KadasLineItem::continuePart( const QgsMapSettings &mapSettings )
 
 void KadasLineItem::endPart()
 {
-  state()->drawStatus = State::DrawStatus::Finished;
+  mDrawStatus = DrawStatus::Finished;
 }
 
 KadasMapItem::AttribDefs KadasLineItem::drawAttribs() const
@@ -347,6 +347,13 @@ void KadasLineItem::setMeasurementMode( MeasurementMode measurementMode, Qgis::A
   mMeasurementMode = measurementMode;
   mAngleUnit = angleUnit;
   emit geometryChanged(); // Trigger re-measurement
+}
+
+KadasMapItem *KadasLineItem::_clone() const
+{
+  KadasLineItem *item = new KadasLineItem( crs() );
+  item->mGeometry = mGeometry->clone();
+  return item;
 }
 
 void KadasLineItem::measureGeometry()

--- a/kadas/gui/mapitems/kadaslineitem.h
+++ b/kadas/gui/mapitems/kadaslineitem.h
@@ -87,7 +87,7 @@ class KADAS_GUI_EXPORT KadasLineItem : public KadasGeometryItem
     const State *constState() const { return static_cast<State *>( mState ); }
 
   protected:
-    KadasMapItem *_clone() const override SIP_FACTORY { return new KadasLineItem( crs() ); }
+    KadasMapItem *_clone() const override SIP_FACTORY;
     State *createEmptyState() const override SIP_FACTORY { return new State(); }
     void recomputeDerived() override;
     void measureGeometry() override;

--- a/kadas/gui/mapitems/kadasmapitem.cpp
+++ b/kadas/gui/mapitems/kadasmapitem.cpp
@@ -69,12 +69,21 @@ KadasMapItem::~KadasMapItem()
 KadasMapItem *KadasMapItem::clone() const
 {
   KadasMapItem *item = _clone();
-  for ( int i = 0, n = metaObject()->propertyCount(); i < n; ++i )
+  item->mDrawStatus = mDrawStatus;
+  item->mEditor = mEditor;
+  if ( !useQgisAnnotations() )
   {
-    QMetaProperty prop = metaObject()->property( i );
-    prop.write( item, prop.read( this ) );
+    for ( int i = 0, n = metaObject()->propertyCount(); i < n; ++i )
+    {
+      QMetaProperty prop = metaObject()->property( i );
+      prop.write( item, prop.read( this ) );
+    }
   }
-  item->setState( constState()->clone() );
+  if ( mState )
+    item->mState = mState->clone();
+
+  item->update();
+
   return item;
 }
 
@@ -170,17 +179,18 @@ void KadasMapItem::setSelected( bool selected )
   update();
 }
 
-void KadasMapItem::setAuthId( const QString &authId )
-{
-  mCrs = QgsCoordinateReferenceSystem( authId );
-  update();
-  emit propertyChanged();
-}
+// void KadasMapItem::setAuthId( const QString &authId )
+// {
+//   mCrs = QgsCoordinateReferenceSystem( authId );
+//   update();
+//   emit propertyChanged();
+// }
 
 void KadasMapItem::setZIndex( int zIndex )
 {
   mZIndex = zIndex;
   update();
+  emit zIndexChanged( zIndex );
   emit propertyChanged();
 }
 
@@ -237,16 +247,21 @@ KadasMapPos KadasMapItem::toMapPos( const KadasItemPos &itemPos, const QgsMapSet
   return KadasMapPos( pos.x(), pos.y() );
 }
 
+QgsPointXY KadasMapItem::toMapPos( const QgsPointXY &itemPos, const QgsMapSettings &settings ) const
+{
+  return QgsCoordinateTransform( mCrs, settings.destinationCrs(), settings.transformContext() ).transform( itemPos );
+}
+
 KadasItemPos KadasMapItem::toItemPos( const KadasMapPos &mapPos, const QgsMapSettings &settings ) const
 {
   QgsPointXY pos = QgsCoordinateTransform( settings.destinationCrs(), mCrs, settings.transformContext() ).transform( mapPos );
   return KadasItemPos( pos.x(), pos.y() );
 }
 
-KadasMapRect KadasMapItem::toMapRect( const KadasItemRect &itemRect, const QgsMapSettings &settings ) const
+QgsRectangle KadasMapItem::toMapRect( const QgsRectangle &itemRect, const QgsMapSettings &settings ) const
 {
   QgsRectangle rect = QgsCoordinateTransform( mCrs, settings.destinationCrs(), settings.transformContext() ).transform( itemRect );
-  return KadasMapRect( rect.xMinimum(), rect.yMinimum(), rect.xMaximum(), rect.yMaximum() );
+  return rect;
 }
 
 KadasItemRect KadasMapItem::toItemRect( const KadasMapRect &itemRect, const QgsMapSettings &settings ) const
@@ -375,13 +390,21 @@ QDomElement KadasMapItem::writeXml( QDomDocument &document ) const
   itemEl.setAttribute( "name", metaObject()->className() );
   itemEl.setAttribute( "crs", crs().authid() );
   itemEl.setAttribute( "editor", editor() );
+  itemEl.setAttribute( "draw_status", qgsEnumValueToKey( mDrawStatus ) );
   if ( associatedLayer() )
   {
     itemEl.setAttribute( "associatedLayer", associatedLayer()->id() );
   }
   QJsonDocument doc;
-  doc.setObject( serialize() );
-  itemEl.appendChild( document.createCDATASection( doc.toJson( QJsonDocument::Compact ) ) );
+  if ( !useQgisAnnotations() )
+  {
+    doc.setObject( serialize() );
+    itemEl.appendChild( document.createCDATASection( doc.toJson( QJsonDocument::Compact ) ) );
+  }
+  else
+  {
+    writeXmlPrivate( itemEl );
+  }
   return itemEl;
 }
 
@@ -389,27 +412,38 @@ KadasMapItem *KadasMapItem::fromXml( const QDomElement &element )
 {
   QDomElement itemEl = element;
   QString name = itemEl.attribute( "name" );
-  QString crs = itemEl.attribute( "crs" );
+  QString crsCode = itemEl.attribute( "crs" );
   QString editor = itemEl.attribute( "editor" );
   QString layerId = itemEl.attribute( "associatedLayer" );
-  QJsonDocument data = QJsonDocument::fromJson( itemEl.firstChild().toCDATASection().data().toLocal8Bit() );
+  DrawStatus status = qgsEnumKeyToValue( itemEl.attribute( "draw_status", qgsEnumValueToKey( DrawStatus::Finished ) ), DrawStatus::Finished );
   KadasMapItem::RegistryItemFactory factory = KadasMapItem::registry()->value( name );
   if ( factory )
   {
-    KadasMapItem *item = factory( QgsCoordinateReferenceSystem( crs ) );
+    QgsCoordinateReferenceSystem crs( crsCode );
+    KadasMapItem *item = factory( crs );
     item->setEditor( editor );
+    item->setDrawStatus( status );
     if ( !layerId.isEmpty() )
     {
       item->associateToLayer( QgsProject::instance()->mapLayer( layerId ) );
     }
-    if ( item->deserialize( data.object() ) )
+    if ( !item->useQgisAnnotations() )
     {
-      return item;
+      QJsonDocument data = QJsonDocument::fromJson( itemEl.firstChild().toCDATASection().data().toLocal8Bit() );
+      if ( item->deserialize( data.object() ) )
+      {
+        return item;
+      }
+      else
+      {
+        delete item;
+        QgsDebugMsgLevel( QString( "Item deserialization failed: %1" ).arg( name ), 2 );
+      }
     }
     else
     {
-      delete item;
-      QgsDebugMsgLevel( QString( "Item deserialization failed: %1" ).arg( name ), 2 );
+      item->readXmlPrivate( element );
+      return item;
     }
   }
   else

--- a/kadas/gui/mapitems/kadasmapitem.cpp
+++ b/kadas/gui/mapitems/kadasmapitem.cpp
@@ -280,12 +280,13 @@ bool KadasMapItem::hitTest( const KadasMapPos &pos, const QgsMapSettings &settin
   QgsRenderContext renderContext = QgsRenderContext::fromMapSettings( settings );
   double radiusmm = QgsSettings().value( "/Map/searchRadiusMM", Qgis::DEFAULT_SEARCH_RADIUS_MM ).toDouble();
   radiusmm = radiusmm > 0 ? radiusmm : Qgis::DEFAULT_SEARCH_RADIUS_MM;
-  double radiusmu = radiusmm * renderContext.scaleFactor() * renderContext.mapToPixel().mapUnitsPerPixel();
+  double radiusmu = radiusmm * renderContext.scaleFactor() * renderContext.devicePixelRatio() * renderContext.mapToPixel().mapUnitsPerPixel();
   KadasMapRect filterRect;
   filterRect.setXMinimum( pos.x() - radiusmu );
   filterRect.setXMaximum( pos.x() + radiusmu );
   filterRect.setYMinimum( pos.y() - radiusmu );
   filterRect.setYMaximum( pos.y() + radiusmu );
+
   return intersects( filterRect, settings );
 }
 

--- a/kadas/gui/mapitems/kadasmapitem.h
+++ b/kadas/gui/mapitems/kadasmapitem.h
@@ -339,8 +339,8 @@ class KADAS_GUI_EXPORT KadasMapItem : public QObject SIP_ABSTRACT
 
     virtual QList<KadasMapItem::Node> nodes( const QgsMapSettings &settings ) const = 0;
 
-    /* Hit test, rect in item crs */
     virtual bool intersects( const QgsRectangle &rect, const QgsMapSettings &settings, bool contains = false ) const = 0;
+
     virtual bool hitTest( const KadasMapPos &pos, const QgsMapSettings &settings ) const;
 
     /* Return the item point to the specified one */

--- a/kadas/gui/mapitems/kadaspointitem.cpp
+++ b/kadas/gui/mapitems/kadaspointitem.cpp
@@ -150,7 +150,8 @@ QList<KadasMapItem::Node> KadasAbstractPointItem::nodes( const QgsMapSettings &s
 
 bool KadasAbstractPointItem::intersects( const QgsRectangle &rect, const QgsMapSettings &settings, bool contains ) const
 {
-  return rect.intersects( boundingBox() );
+  QgsRectangle itemRect = QgsCoordinateTransform( settings.destinationCrs(), mCrs, QgsProject::instance() ).transform( rect );
+  return itemRect.intersects( boundingBox() );
 }
 
 

--- a/kadas/gui/mapitems/kadaspointitem.cpp
+++ b/kadas/gui/mapitems/kadaspointitem.cpp
@@ -17,121 +17,77 @@
 #include <QJsonArray>
 
 #include <qgis/qgspoint.h>
+#include <qgis/qgsproject.h>
 #include <qgis/qgsmultipoint.h>
 #include <qgis/qgsmapsettings.h>
+#include <qgis/qgsmarkersymbol.h>
+#include <qgis/qgsmarkersymbollayer.h>
+#include <qgis/qgssymbollayerutils.h>
 
 #include "kadas/gui/mapitems/kadaspointitem.h"
 
-
-QJsonObject KadasPointItem::State::serialize() const
+KadasAbstractPointItem::KadasAbstractPointItem( const QgsCoordinateReferenceSystem &crs )
+  : KadasMapItem( crs )
 {
-  QJsonArray pts;
-  for ( const KadasItemPos &pos : points )
-  {
-    QJsonArray p;
-    p.append( pos.x() );
-    p.append( pos.y() );
-    pts.append( p );
-  }
-  QJsonObject json;
-  json["status"] = static_cast<int>( drawStatus );
-  json["points"] = pts;
-  return json;
-}
-
-bool KadasPointItem::State::deserialize( const QJsonObject &json )
-{
-  drawStatus = static_cast<DrawStatus>( json["status"].toInt() );
-  points.clear();
-  QJsonArray pts = json["points"].toArray();
-  for ( QJsonValue pValue : pts )
-  {
-    QJsonArray p = pValue.toArray();
-    points.append( KadasItemPos( p.at( 0 ).toDouble(), p.at( 1 ).toDouble() ) );
-  }
-  return true;
-}
-
-KadasPointItem::KadasPointItem( const QgsCoordinateReferenceSystem &crs, IconType icon )
-  : KadasGeometryItem( crs )
-{
-  setIconType( icon );
   clear();
 }
 
-KadasItemPos KadasPointItem::position() const
+void KadasAbstractPointItem::translate( double dx, double dy )
 {
-  double x = 0., y = 0.;
-  for ( const KadasItemPos &point : constState()->points )
-  {
-    x += point.x();
-    y += point.y();
-  }
-  int n = std::max( 1, constState()->points.size() );
-  return KadasItemPos( x / n, y / n );
+  QgsGeometry geom = QgsGeometry::fromPointXY( mPoint );
+  geom.translate( dx, dy );
+  setItemGeometry( *qgsgeometry_cast<const QgsPoint *>( geom.constGet() ) );
+  update();
 }
 
-void KadasPointItem::setPosition( const KadasItemPos &pos )
+
+void KadasAbstractPointItem::setPoint( const QgsPointXY &point )
 {
-  if ( state()->points.isEmpty() )
-  {
-    state()->points.append( pos );
-    endPart();
-    recomputeDerived();
-  }
-  else
-  {
-    KadasItemPos prevPos = position();
-    double dx = pos.x() - prevPos.x();
-    double dy = pos.y() - prevPos.y();
-    for ( KadasItemPos &point : state()->points )
-    {
-      point.setX( point.x() + dx );
-      point.setY( point.y() + dy );
-    }
-    if ( mGeometry )
-    {
-      mGeometry->transformVertices( [dx, dy]( const QgsPoint &p ) { return QgsPoint( p.x() + dx, p.y() + dy ); } );
-    }
-    update();
-  }
+  mPoint = point;
+  setItemGeometry( point );
+  update();
 }
 
-bool KadasPointItem::startPart( const KadasMapPos &firstPoint, const QgsMapSettings &mapSettings )
+void KadasAbstractPointItem::setState( const KadasMapItem::State *state )
 {
-  state()->drawStatus = State::DrawStatus::Drawing;
-  state()->points.append( toItemPos( firstPoint, mapSettings ) );
-  recomputeDerived();
+  KadasMapItem::setState( state );
+  updateQgsAnnotation();
+}
+
+bool KadasAbstractPointItem::startPart( const KadasMapPos &firstPoint, const QgsMapSettings &mapSettings )
+{
+  mDrawStatus = DrawStatus::Drawing;
+  setPoint( QgsPoint( firstPoint ) );
   return false;
 }
 
-bool KadasPointItem::startPart( const AttribValues &values, const QgsMapSettings &mapSettings )
+bool KadasAbstractPointItem::startPart( const AttribValues &values, const QgsMapSettings &mapSettings )
 {
   return startPart( KadasMapPos( values[AttrX], values[AttrY] ), mapSettings );
 }
 
-void KadasPointItem::setCurrentPoint( const KadasMapPos &p, const QgsMapSettings &mapSettings )
+void KadasAbstractPointItem::setCurrentPoint( const KadasMapPos &p, const QgsMapSettings &mapSettings )
 {
   // Do nothing
 }
 
-void KadasPointItem::setCurrentAttributes( const AttribValues &values, const QgsMapSettings &mapSettings )
+void KadasAbstractPointItem::setCurrentAttributes( const AttribValues &values, const QgsMapSettings &mapSettings )
 {
   // Do nothing
 }
 
-bool KadasPointItem::continuePart( const QgsMapSettings &mapSettings )
+bool KadasAbstractPointItem::continuePart( const QgsMapSettings &mapSettings )
 {
   // No further action allowed
   return false;
 }
 
-void KadasPointItem::endPart()
+void KadasAbstractPointItem::endPart()
 {
-  state()->drawStatus = State::DrawStatus::Finished;
+  mDrawStatus = DrawStatus::Finished;
 }
 
-KadasMapItem::AttribDefs KadasPointItem::drawAttribs() const
+KadasMapItem::AttribDefs KadasAbstractPointItem::drawAttribs() const
 {
   AttribDefs attributes;
   attributes.insert( AttrX, NumericAttribute { "x" } );
@@ -139,7 +95,7 @@ KadasMapItem::AttribDefs KadasPointItem::drawAttribs() const
   return attributes;
 }
 
-KadasMapItem::AttribValues KadasPointItem::drawAttribsFromPosition( const KadasMapPos &pos, const QgsMapSettings &mapSettings ) const
+KadasMapItem::AttribValues KadasAbstractPointItem::drawAttribsFromPosition( const KadasMapPos &pos, const QgsMapSettings &mapSettings ) const
 {
   AttribValues values;
   values.insert( AttrX, pos.x() );
@@ -147,90 +103,270 @@ KadasMapItem::AttribValues KadasPointItem::drawAttribsFromPosition( const KadasM
   return values;
 }
 
-KadasMapPos KadasPointItem::positionFromDrawAttribs( const AttribValues &values, const QgsMapSettings &mapSettings ) const
+KadasMapPos KadasAbstractPointItem::positionFromDrawAttribs( const AttribValues &values, const QgsMapSettings &mapSettings ) const
 {
   return KadasMapPos( values[AttrX], values[AttrY] );
 }
 
-KadasMapItem::EditContext KadasPointItem::getEditContext( const KadasMapPos &pos, const QgsMapSettings &mapSettings ) const
+KadasMapItem::EditContext KadasAbstractPointItem::getEditContext( const KadasMapPos &pos, const QgsMapSettings &mapSettings ) const
 {
-  for ( int i = 0, n = constState()->points.size(); i < n; ++i )
+  QgsPointXY testPos = toMapPos( point(), mapSettings );
+  if ( pos.sqrDist( KadasMapPos::fromPoint( testPos ) ) < pickTolSqr( mapSettings ) )
   {
-    KadasMapPos testPos = toMapPos( constState()->points[i], mapSettings );
-    if ( pos.sqrDist( testPos ) < pickTolSqr( mapSettings ) )
-    {
-      return EditContext( QgsVertexId( i, 0, 0 ), testPos, drawAttribs() );
-    }
+    return EditContext( QgsVertexId( 0, 0, 0 ), KadasMapPos::fromPoint( testPos ), drawAttribs() );
   }
   return EditContext();
 }
 
-void KadasPointItem::edit( const EditContext &context, const KadasMapPos &newPoint, const QgsMapSettings &mapSettings )
+void KadasAbstractPointItem::edit( const EditContext &context, const KadasMapPos &newPoint, const QgsMapSettings &mapSettings )
 {
-  if ( context.vidx.part >= 0 && context.vidx.part < state()->points.size() )
-  {
-    state()->points[context.vidx.part] = toItemPos( newPoint, mapSettings );
-    recomputeDerived();
-  }
+  setPoint( QgsPoint( toItemPos( newPoint, mapSettings ) ) );
 }
 
-void KadasPointItem::edit( const EditContext &context, const AttribValues &values, const QgsMapSettings &mapSettings )
+void KadasAbstractPointItem::edit( const EditContext &context, const AttribValues &values, const QgsMapSettings &mapSettings )
 {
   edit( context, KadasMapPos( values[AttrX], values[AttrY] ), mapSettings );
 }
 
-KadasMapItem::AttribValues KadasPointItem::editAttribsFromPosition( const EditContext &context, const KadasMapPos &pos, const QgsMapSettings &mapSettings ) const
+KadasMapItem::AttribValues KadasAbstractPointItem::editAttribsFromPosition( const EditContext &context, const KadasMapPos &pos, const QgsMapSettings &mapSettings ) const
 {
   return drawAttribsFromPosition( pos, mapSettings );
 }
 
-KadasMapPos KadasPointItem::positionFromEditAttribs( const EditContext &context, const AttribValues &values, const QgsMapSettings &mapSettings ) const
+KadasMapPos KadasAbstractPointItem::positionFromEditAttribs( const EditContext &context, const AttribValues &values, const QgsMapSettings &mapSettings ) const
 {
   return positionFromDrawAttribs( values, mapSettings );
 }
 
-void KadasPointItem::addPartFromGeometry( const QgsAbstractGeometry &geom )
+QgsPointXY KadasAbstractPointItem::point() const
 {
-  QList<const QgsPoint *> geoms;
-  if ( dynamic_cast<const QgsGeometryCollection *>( &geom ) )
+  return mPoint;
+}
+
+QList<KadasMapItem::Node> KadasAbstractPointItem::nodes( const QgsMapSettings &settings ) const
+{
+  return { { toMapPos( KadasItemPos::fromPoint( point() ), settings ) } };
+}
+
+bool KadasAbstractPointItem::intersects( const QgsRectangle &rect, const QgsMapSettings &settings, bool contains ) const
+{
+  return rect.intersects( boundingBox() );
+}
+
+
+KadasPointItem::KadasPointItem( const QgsCoordinateReferenceSystem &crs, Qgis::MarkerShape icon )
+  : KadasAbstractPointItem( crs )
+  , mShape( icon )
+{
+  mQgsItem = new QgsAnnotationMarkerItem( QgsPoint() );
+  connect( this, &KadasMapItem::zIndexChanged, this, [=]( int index ) { mQgsItem->setZIndex( index ); } );
+}
+
+QgsAnnotationMarkerItem *KadasPointItem::annotationItem( const QgsCoordinateReferenceSystem &crs ) const
+{
+  QgsAnnotationMarkerItem *item = mQgsItem->clone();
+  if ( mCrs != crs )
   {
-    const QgsGeometryCollection &collection = dynamic_cast<const QgsGeometryCollection &>( geom );
-    for ( int i = 0, n = collection.numGeometries(); i < n; ++i )
+    QgsCoordinateTransform ct( mCrs, crs, QgsProject::instance() );
+    item->setGeometry( QgsPoint( ct.transform( item->geometry() ) ) );
+  }
+  return item;
+}
+
+void KadasPointItem::setShape( Qgis::MarkerShape shape )
+{
+  mShape = shape;
+  updateQgsAnnotation();
+}
+
+
+void KadasPointItem::setIconSize( int size )
+{
+  mIconSize = size;
+  updateQgsAnnotation();
+}
+
+void KadasPointItem::setColor( const QColor &color )
+{
+  mFillColor = color;
+  updateQgsAnnotation();
+}
+
+void KadasPointItem::setStrokeColor( const QColor &strokeColor )
+{
+  mStrokeColor = strokeColor;
+  updateQgsAnnotation();
+}
+
+void KadasPointItem::setStrokeWidth( double width )
+{
+  mStrokeWidth = width;
+  updateQgsAnnotation();
+}
+
+void KadasPointItem::setStrokeStyle( const Qt::PenStyle &style )
+{
+  mStrokeStyle = style;
+  updateQgsAnnotation();
+}
+
+void KadasPointItem::setItemGeometry( const QgsPointXY &point )
+{
+  mQgsItem->setGeometry( QgsPoint( point ) );
+}
+
+void KadasPointItem::updateQgsAnnotation()
+{
+  QgsSimpleMarkerSymbolLayer *symbolLayer = new QgsSimpleMarkerSymbolLayer();
+  symbolLayer->setSizeUnit( Qgis::RenderUnit::Points );
+  symbolLayer->setShape( mShape );
+  symbolLayer->setSize( mIconSize );
+  symbolLayer->setStrokeWidth( mStrokeWidth );
+  symbolLayer->setStrokeWidthUnit( Qgis::RenderUnit::Points );
+  symbolLayer->setStrokeColor( mStrokeColor );
+  symbolLayer->setColor( mFillColor );
+  symbolLayer->setStrokeStyle( mStrokeStyle );
+  mQgsItem->setSymbol( new QgsMarkerSymbol( { symbolLayer } ) );
+
+  update();
+}
+
+KadasMapItem *KadasPointItem::_clone() const SIP_FACTORY
+{
+  KadasPointItem *item = new KadasPointItem( crs() );
+  item->mQgsItem = mQgsItem->clone();
+  item->mShape = mShape;
+  item->mIconSize = mIconSize;
+  item->mStrokeColor = mStrokeColor;
+  item->mStrokeWidth = mStrokeWidth;
+  item->mFillColor = mFillColor;
+  return item;
+}
+
+void KadasPointItem::writeXmlPrivate( QDomElement &element ) const
+{
+  //element.setAttribute("status", static_cast<int>( state().drawStatus ));
+  element.setAttribute( "shape", qgsEnumValueToKey( mShape ) );
+  element.setAttribute( "size", mIconSize );
+  element.setAttribute( "stroke_color", mStrokeColor.name() );
+  element.setAttribute( "stroke_width", mStrokeWidth );
+  element.setAttribute( "fill_color", mFillColor.name() );
+  element.setAttribute( "geometry", point().asWkt() );
+}
+
+void KadasPointItem::readXmlPrivate( const QDomElement &element )
+{
+  if ( !element.hasAttribute( "shape" ) )
+  {
+    // migration code
+    QJsonObject data = QJsonDocument::fromJson( element.firstChild().toCDATASection().data().toLocal8Bit() ).object();
+    if ( data.contains( "props" ) )
     {
-      if ( dynamic_cast<const QgsPoint *>( collection.geometryN( i ) ) )
+      QJsonObject props = data["props"].toObject();
+
+      mCrs = QgsCoordinateReferenceSystem( props.value( "authId" ).toString() );
+      mEditor = props.value( "editor" ).toString();
+      mIconSize = props.value( "iconSize" ).toInt();
+
+      QStringList brushStr = props.value( "iconFill" ).toString().split( ";" );
+      if ( brushStr.size() )
+        mFillColor = QColor( brushStr[0] );
+
+      QStringList penStr = props.value( "iconOutline" ).toString().split( ";" );
+      if ( penStr.size() > 1 )
       {
-        geoms.append( static_cast<const QgsPoint *>( collection.geometryN( i ) ) );
+        mStrokeColor = QColor( penStr[0] );
+        mStrokeWidth = penStr[1].toInt();
+      }
+
+      // this must be done at the end
+      switch ( props.value( "iconType" ).toInt( 1 ) )
+      {
+        case 1:
+          mShape = Qgis::MarkerShape::Cross;
+          break;
+        case 2:
+          mShape = Qgis::MarkerShape::Cross2;
+          break;
+        case 3:
+          mShape = Qgis::MarkerShape::Square;
+          break;
+        case 4:
+          mShape = Qgis::MarkerShape::Circle;
+          break;
+        case 5:
+          mShape = Qgis::MarkerShape::Square;
+          break;
+        case 6:
+          mShape = Qgis::MarkerShape::Triangle;
+          break;
+        case 7:
+          mShape = Qgis::MarkerShape::Triangle;
+          break;
+        default:
+          mShape = Qgis::MarkerShape::Circle;
+          break;
       }
     }
+    if ( data.contains( "state" ) )
+    {
+      const QJsonArray point = data.value( "state" ).toObject().value( "points" ).toArray().first().toArray();
+      setPoint( QgsPointXY( point.at( 0 ).toDouble(), point.at( 1 ).toDouble() ) );
+    }
   }
-  else if ( dynamic_cast<const QgsPoint *>( &geom ) )
+  else
   {
-    geoms.append( static_cast<const QgsPoint *>( &geom ) );
+    mShape = qgsEnumKeyToValue( element.attribute( "shape", qgsEnumValueToKey( Qgis::MarkerShape::Circle ) ), Qgis::MarkerShape::Circle );
+    mIconSize = element.attribute( "size", "4" ).toInt();
+    mStrokeColor = QColor( element.attribute( "stroke_color", QColor( Qt::red ).name() ) );
+    mStrokeWidth = element.attribute( "stroke_width", "1" ).toInt();
+    mFillColor = QColor( element.attribute( "fill_color", QColor( Qt::white ).name() ) );
+    setPoint( QgsGeometry::fromWkt( element.attribute( "geometry" ) ).asPoint() );
   }
-  for ( const QgsPoint *point : geoms )
-  {
-    state()->points.append( KadasItemPos( point->x(), point->y(), point->z() ) );
-    endPart();
-  }
-  recomputeDerived();
+  updateQgsAnnotation();
 }
 
-const QgsMultiPoint *KadasPointItem::geometry() const
+
+QgsRectangle KadasPointItem::boundingBox() const
 {
-  return static_cast<QgsMultiPoint *>( mGeometry );
+  return mQgsItem->boundingBox();
 }
 
-QgsMultiPoint *KadasPointItem::geometry()
+void KadasPointItem::render( QgsRenderContext &context ) const
 {
-  return static_cast<QgsMultiPoint *>( mGeometry );
+  QgsFeedback fb;
+  mQgsItem->render( context, &fb );
 }
 
-void KadasPointItem::recomputeDerived()
+QString KadasPointItem::asKml( const QgsRenderContext &context, QuaZip *kmzZip ) const
 {
-  QgsMultiPoint *multiGeom = new QgsMultiPoint();
-  for ( const KadasItemPos &point : state()->points )
-  {
-    multiGeom->addGeometry( new QgsPoint( point ) );
-  }
-  setInternalGeometry( multiGeom );
+  if ( mQgsItem->geometry().isEmpty() )
+    return QString();
+
+  auto color2hex = []( const QColor &c ) { return QString( "%1%2%3%4" ).arg( c.alpha(), 2, 16, QChar( '0' ) ).arg( c.blue(), 2, 16, QChar( '0' ) ).arg( c.green(), 2, 16, QChar( '0' ) ).arg( c.red(), 2, 16, QChar( '0' ) ); };
+
+  QString outString;
+  QTextStream outStream( &outString );
+  outStream << "<Placemark>\n";
+  outStream << QString( "<name>%1</name>\n" ).arg( exportName() );
+  outStream << "<Style>\n";
+  outStream << QString( "<LineStyle><width>%1</width><color>%2</color></LineStyle>\n<PolyStyle><fill>%3</fill><color>%4</color></PolyStyle>\n" )
+                 .arg( strokeWidth() )
+                 .arg( color2hex( strokeColor() ) )
+                 .arg( 1 )
+                 .arg( color2hex( color() ) );
+  outStream << "</Style>\n";
+  outStream << "<ExtendedData>\n";
+  outStream << "<SchemaData schemaUrl=\"#KadasGeometryItem\">\n";
+  outStream << QString( "<SimpleData name=\"icon_type\">%1</SimpleData>\n" ).arg( static_cast<int>( mShape ) );
+  outStream << QString( "<SimpleData name=\"outline_style\">%1</SimpleData>\n" ).arg( QgsSymbolLayerUtils::encodePenStyle( QPen( mStrokeColor, mStrokeWidth ).style() ) );
+  outStream << QString( "<SimpleData name=\"fill_style\">%1</SimpleData>\n" ).arg( QgsSymbolLayerUtils::encodeBrushStyle( QBrush( mFillColor ).style() ) );
+  outStream << "</SchemaData>\n";
+  outStream << "</ExtendedData>\n";
+  QgsPoint point = QgsPoint( mQgsItem->geometry() );
+  point.transform( QgsCoordinateTransform( mCrs, QgsCoordinateReferenceSystem( "EPSG:4326" ), QgsProject::instance() ) );
+  outStream << point.asKml( 6 ) << "\n";
+  outStream << "</Placemark>\n";
+  outStream.flush();
+  return outString;
 }

--- a/kadas/gui/mapitems/kadaspointitem.h
+++ b/kadas/gui/mapitems/kadaspointitem.h
@@ -17,16 +17,28 @@
 #ifndef KADASPOINTITEM_H
 #define KADASPOINTITEM_H
 
-#include "kadas/gui/mapitems/kadasgeometryitem.h"
+#include <QColor>
 
-class KADAS_GUI_EXPORT KadasPointItem : public KadasGeometryItem
+
+#include "qgis/qgsannotationmarkeritem.h"
+
+#include "kadas/gui/mapitems/kadasmapitem.h"
+
+class QuaZip;
+
+class KADAS_GUI_EXPORT KadasAbstractPointItem : public KadasMapItem SIP_ABSTRACT
 {
     Q_OBJECT
-
   public:
-    KadasPointItem( const QgsCoordinateReferenceSystem &crs, KadasGeometryItem::IconType icon = KadasGeometryItem::IconType::ICON_CIRCLE );
+    KadasAbstractPointItem( const QgsCoordinateReferenceSystem &crs );
 
-    QString itemName() const override { return tr( "Point" ); }
+    virtual QgsPointXY point() const;
+    virtual void setPoint( const QgsPointXY &point );
+
+    virtual void setItemGeometry( const QgsPointXY &point ) = 0;
+
+    virtual void translate( double dx, double dy ) override;
+    virtual void setState( const KadasMapItem::State *state ) override;
 
     bool startPart( const KadasMapPos &firstPoint, const QgsMapSettings &mapSettings ) override;
     bool startPart( const AttribValues &values, const QgsMapSettings &mapSettings ) override;
@@ -35,39 +47,25 @@ class KADAS_GUI_EXPORT KadasPointItem : public KadasGeometryItem
     bool continuePart( const QgsMapSettings &mapSettings ) override;
     void endPart() override;
 
-    AttribDefs drawAttribs() const override;
-    AttribValues drawAttribsFromPosition( const KadasMapPos &pos, const QgsMapSettings &mapSettings ) const override;
-    KadasMapPos positionFromDrawAttribs( const AttribValues &values, const QgsMapSettings &mapSettings ) const override;
+    virtual bool intersects( const QgsRectangle &rect, const QgsMapSettings &settings, bool contains ) const override;
+
+    virtual QList<KadasMapItem::Node> nodes( const QgsMapSettings &settings ) const override;
 
     EditContext getEditContext( const KadasMapPos &pos, const QgsMapSettings &mapSettings ) const override;
     void edit( const EditContext &context, const KadasMapPos &newPoint, const QgsMapSettings &mapSettings ) override;
     void edit( const EditContext &context, const AttribValues &values, const QgsMapSettings &mapSettings ) override;
 
+    AttribDefs drawAttribs() const override;
+    AttribValues drawAttribsFromPosition( const KadasMapPos &pos, const QgsMapSettings &mapSettings ) const override;
+    KadasMapPos positionFromDrawAttribs( const AttribValues &values, const QgsMapSettings &mapSettings ) const override;
+
     AttribValues editAttribsFromPosition( const EditContext &context, const KadasMapPos &pos, const QgsMapSettings &mapSettings ) const override;
     KadasMapPos positionFromEditAttribs( const EditContext &context, const AttribValues &values, const QgsMapSettings &mapSettings ) const override;
 
-    KadasItemPos position() const override;
-    void setPosition( const KadasItemPos &pos ) override;
-
-    Qgis::GeometryType geometryType() const override { return Qgis::GeometryType::Point; }
-    void addPartFromGeometry( const QgsAbstractGeometry &geom ) override;
-
-    const QgsMultiPoint *geometry() const;
-
-    struct KADAS_GUI_EXPORT State : KadasMapItem::State
-    {
-        QList<KadasItemPos> points;
-        void assign( const KadasMapItem::State *other ) override { *this = *static_cast<const State *>( other ); }
-        State *clone() const override SIP_FACTORY { return new State( *this ); }
-        QJsonObject serialize() const override;
-        bool deserialize( const QJsonObject &json ) override;
-    };
-    const State *constState() const { return static_cast<State *>( mState ); }
-
   protected:
-    KadasMapItem *_clone() const override SIP_FACTORY { return new KadasPointItem( crs() ); }
-    State *createEmptyState() const override SIP_FACTORY { return new State(); }
-    void recomputeDerived() override;
+    bool useQgisAnnotations() const override { return true; }
+    virtual void updateQgsAnnotation() = 0;
+
 
   private:
     enum AttribIds
@@ -76,8 +74,64 @@ class KADAS_GUI_EXPORT KadasPointItem : public KadasGeometryItem
       AttrY
     };
 
-    QgsMultiPoint *geometry();
+    QgsPointXY mPoint;
+
     State *state() { return static_cast<State *>( mState ); }
+};
+
+
+class KADAS_GUI_EXPORT KadasPointItem : public KadasAbstractPointItem
+{
+    Q_OBJECT
+    Q_PROPERTY( Qgis::MarkerShape mShape READ shape WRITE setShape )
+    Q_PROPERTY( int mIconSize READ iconSize WRITE setIconSize )
+    Q_PROPERTY( QColor mFillColor READ color WRITE setColor )
+    Q_PROPERTY( QColor mStrokeColor READ strokeColor WRITE setStrokeColor )
+    Q_PROPERTY( double mStrokeWidth READ strokeWidth WRITE setStrokeWidth )
+    Q_PROPERTY( Qt::PenStyle mStrokeStyle READ strokeStyle WRITE setStrokeStyle )
+
+  public:
+    KadasPointItem( const QgsCoordinateReferenceSystem &crs, Qgis::MarkerShape icon = Qgis::MarkerShape::Circle );
+
+    virtual QgsAnnotationMarkerItem *annotationItem( const QgsCoordinateReferenceSystem &crs = QgsCoordinateReferenceSystem() ) const override SIP_FACTORY;
+
+    virtual QString itemName() const override { return tr( "Point" ); }
+
+    virtual void setItemGeometry( const QgsPointXY &point ) override;
+
+    virtual QgsRectangle boundingBox() const override;
+
+    virtual void render( QgsRenderContext &context ) const override;
+    virtual QString asKml( const QgsRenderContext &context, QuaZip *kmzZip ) const override SIP_SKIP;
+
+    void setShape( Qgis::MarkerShape shape );
+    Qgis::MarkerShape shape() const { return mShape; }
+    void setIconSize( int size );
+    int iconSize() const { return mIconSize; }
+    void setColor( const QColor &color );
+    QColor color() const { return mFillColor; }
+    void setStrokeColor( const QColor &strokeColor );
+    QColor strokeColor() const { return mStrokeColor; }
+    void setStrokeWidth( double width );
+    double strokeWidth() const { return mStrokeWidth; }
+    void setStrokeStyle( const Qt::PenStyle &style );
+    Qt::PenStyle strokeStyle() const { return mStrokeStyle; }
+
+  protected:
+    virtual KadasMapItem *_clone() const override;
+    virtual void writeXmlPrivate( QDomElement &element ) const override;
+    virtual void readXmlPrivate( const QDomElement &element ) override;
+
+  private:
+    void updateQgsAnnotation() override;
+
+    QgsAnnotationMarkerItem *mQgsItem = nullptr;
+    Qgis::MarkerShape mShape = Qgis::MarkerShape::Circle;
+    int mIconSize = 4;
+    QColor mStrokeColor = Qt::red;
+    double mStrokeWidth = 1;
+    QColor mFillColor = Qt::white;
+    Qt::PenStyle mStrokeStyle = Qt::PenStyle::SolidLine;
 };
 
 #endif // KADASPOINTITEM_H

--- a/kadas/gui/mapitems/kadaspolygonitem.cpp
+++ b/kadas/gui/mapitems/kadaspolygonitem.cpp
@@ -48,7 +48,7 @@ QJsonObject KadasPolygonItem::State::serialize() const
     pts.append( prt );
   }
   QJsonObject json;
-  json["status"] = static_cast<int>( drawStatus );
+  //json["status"] = static_cast<int>( drawStatus );
   ;
   json["points"] = pts;
   return json;
@@ -56,7 +56,7 @@ QJsonObject KadasPolygonItem::State::serialize() const
 
 bool KadasPolygonItem::State::deserialize( const QJsonObject &json )
 {
-  drawStatus = static_cast<DrawStatus>( json["status"].toInt() );
+  //drawStatus = static_cast<DrawStatus>( json["status"].toInt() );
   points.clear();
   QJsonArray pts = json["points"].toArray();
   for ( QJsonValue prtValue : pts )
@@ -141,7 +141,7 @@ void KadasPolygonItem::setPosition( const KadasItemPos &pos )
 bool KadasPolygonItem::startPart( const KadasMapPos &firstPoint, const QgsMapSettings &mapSettings )
 {
   KadasItemPos itemPos = toItemPos( firstPoint, mapSettings );
-  state()->drawStatus = State::DrawStatus::Drawing;
+  mDrawStatus = DrawStatus::Drawing;
   state()->points.append( QList<KadasItemPos>() );
   state()->points.last().append( itemPos );
   state()->points.last().append( itemPos );
@@ -182,7 +182,7 @@ bool KadasPolygonItem::continuePart( const QgsMapSettings &mapSettings )
 
 void KadasPolygonItem::endPart()
 {
-  state()->drawStatus = State::DrawStatus::Finished;
+  mDrawStatus = DrawStatus::Finished;
 }
 
 KadasMapItem::AttribDefs KadasPolygonItem::drawAttribs() const
@@ -325,6 +325,13 @@ void KadasPolygonItem::addPartFromGeometry( const QgsAbstractGeometry &geom )
 const QgsMultiPolygon *KadasPolygonItem::geometry() const
 {
   return static_cast<QgsMultiPolygon *>( mGeometry );
+}
+
+KadasMapItem *KadasPolygonItem::_clone() const
+{
+  KadasPolygonItem *item = new KadasPolygonItem( crs() );
+  item->mGeometry = mGeometry->clone();
+  return item;
 }
 
 QgsMultiPolygon *KadasPolygonItem::geometry()

--- a/kadas/gui/mapitems/kadaspolygonitem.h
+++ b/kadas/gui/mapitems/kadaspolygonitem.h
@@ -74,7 +74,7 @@ class KADAS_GUI_EXPORT KadasPolygonItem : public KadasGeometryItem
     const State *constState() const { return static_cast<State *>( mState ); }
 
   protected:
-    KadasMapItem *_clone() const override SIP_FACTORY { return new KadasPolygonItem( crs() ); }
+    KadasMapItem *_clone() const override SIP_FACTORY;
     State *createEmptyState() const override SIP_FACTORY { return new State(); }
     void recomputeDerived() override;
     void measureGeometry() override;

--- a/kadas/gui/mapitems/kadasrectangleitem.cpp
+++ b/kadas/gui/mapitems/kadasrectangleitem.cpp
@@ -45,7 +45,7 @@ QJsonObject KadasRectangleItem::State::serialize() const
     pt2.append( p );
   }
   QJsonObject json;
-  json["status"] = static_cast<int>( drawStatus );
+  //json["status"] = static_cast<int>( drawStatus );
   json["p1"] = pt1;
   json["p2"] = pt2;
   return json;
@@ -56,7 +56,7 @@ bool KadasRectangleItem::State::deserialize( const QJsonObject &json )
   p1.clear();
   p2.clear();
 
-  drawStatus = static_cast<DrawStatus>( json["status"].toInt() );
+  //drawStatus = static_cast<DrawStatus>( json["status"].toInt() );
   for ( QJsonValue val : json["p1"].toArray() )
   {
     QJsonArray pos = val.toArray();
@@ -119,7 +119,7 @@ void KadasRectangleItem::setPosition( const KadasItemPos &pos )
 bool KadasRectangleItem::startPart( const KadasMapPos &firstPoint, const QgsMapSettings &mapSettings )
 {
   KadasItemPos itemPos = toItemPos( firstPoint, mapSettings );
-  state()->drawStatus = State::DrawStatus::Drawing;
+  mDrawStatus = DrawStatus::Drawing;
   state()->p1.append( itemPos );
   state()->p2.append( itemPos );
   recomputeDerived();
@@ -150,7 +150,7 @@ bool KadasRectangleItem::continuePart( const QgsMapSettings &mapSettings )
 
 void KadasRectangleItem::endPart()
 {
-  state()->drawStatus = State::DrawStatus::Finished;
+  mDrawStatus = DrawStatus::Finished;
 }
 
 KadasMapItem::AttribDefs KadasRectangleItem::drawAttribs() const
@@ -318,6 +318,13 @@ void KadasRectangleItem::measureGeometry()
     totalArea += area;
   }
   mTotalMeasurement = formatArea( totalArea, areaBaseUnit() );
+}
+
+KadasMapItem *KadasRectangleItem::_clone() const
+{
+  KadasRectangleItem *item = new KadasRectangleItem( crs() );
+  item->mGeometry = mGeometry->clone();
+  return item;
 }
 
 void KadasRectangleItem::recomputeDerived()

--- a/kadas/gui/mapitems/kadasrectangleitem.h
+++ b/kadas/gui/mapitems/kadasrectangleitem.h
@@ -79,7 +79,7 @@ class KADAS_GUI_EXPORT KadasRectangleItem : public KadasGeometryItem
       AttrY
     };
 
-    KadasMapItem *_clone() const override SIP_FACTORY { return new KadasRectangleItem( crs() ); }
+    KadasMapItem *_clone() const override SIP_FACTORY;
     QgsMultiPolygon *geometry();
     State *state() { return static_cast<State *>( mState ); }
 };

--- a/kadas/gui/mapitems/kadasrectangleitembase.cpp
+++ b/kadas/gui/mapitems/kadasrectangleitembase.cpp
@@ -58,7 +58,7 @@ QJsonObject KadasRectangleItemBase::State::serialize() const
   rectCenterPoint.append( mRectangleCenterPoint.y() );
 
   QJsonObject json;
-  json["status"] = static_cast<int>( drawStatus );
+  //json["status"] = static_cast<int>( drawStatus );
   json["pos"] = pos;
   json["angle"] = mAngle;
   json["offsetX"] = mOffsetX;
@@ -75,7 +75,7 @@ bool KadasRectangleItemBase::State::deserialize( const QJsonObject &json )
   // frame is enable by default, but for openng of older projects with texts (that had no frame), we disable it
   mFrame = json.contains( "frame" ) ? json["frame"].toBool() : false;
 
-  drawStatus = static_cast<DrawStatus>( json["status"].toInt() );
+  //drawStatus = static_cast<DrawStatus>( json["status"].toInt() );
   QJsonArray p = json["pos"].toArray();
   mPos = KadasItemPos( p.at( 0 ).toDouble(), p.at( 1 ).toDouble() );
   mAngle = json["angle"].toDouble();
@@ -132,7 +132,7 @@ void KadasRectangleItemBase::setPosition( const KadasItemPos &pos )
   if ( !mPosLocked )
   {
     state()->mPos = pos;
-    state()->drawStatus = State::DrawStatus::Finished;
+    mDrawStatus = DrawStatus::Finished;
     update();
   }
 }
@@ -142,7 +142,7 @@ void KadasRectangleItemBase::setState( const KadasMapItem::State *state )
   KadasMapItem::setState( state );
 }
 
-KadasItemRect KadasRectangleItemBase::boundingBox() const
+QgsRectangle KadasRectangleItemBase::boundingBox() const
 {
   double xmin = constState()->mPos.x(), xmax = constState()->mPos.x();
   double ymin = constState()->mPos.y(), ymax = constState()->mPos.y();
@@ -153,7 +153,7 @@ KadasItemRect KadasRectangleItemBase::boundingBox() const
     ymin = std::min( ymin, p.y() );
     ymax = std::max( ymax, p.y() );
   }
-  return KadasItemRect( xmin, ymin, xmax, ymax );
+  return QgsRectangle( xmin, ymin, xmax, ymax );
 }
 
 KadasMapItem::Margin KadasRectangleItemBase::margin() const
@@ -194,7 +194,7 @@ QList<KadasMapItem::Node> KadasRectangleItemBase::nodes( const QgsMapSettings &s
   return nodes;
 }
 
-bool KadasRectangleItemBase::intersects( const KadasMapRect &rect, const QgsMapSettings &settings, bool contains ) const
+bool KadasRectangleItemBase::intersects( const QgsRectangle &rect, const QgsMapSettings &settings, bool contains ) const
 {
   if ( constState()->mSize.isEmpty() )
   {
@@ -351,7 +351,7 @@ void KadasRectangleItemBase::render( QgsRenderContext &context ) const
 
 bool KadasRectangleItemBase::startPart( const KadasMapPos &firstPoint, const QgsMapSettings &mapSettings )
 {
-  state()->drawStatus = State::DrawStatus::Drawing;
+  mDrawStatus = DrawStatus::Drawing;
   state()->mPos = toItemPos( firstPoint, mapSettings );
   update();
   return false;
@@ -380,7 +380,7 @@ bool KadasRectangleItemBase::continuePart( const QgsMapSettings &mapSettings )
 
 void KadasRectangleItemBase::endPart()
 {
-  state()->drawStatus = State::DrawStatus::Finished;
+  mDrawStatus = DrawStatus::Finished;
 }
 
 KadasMapItem::AttribDefs KadasRectangleItemBase::drawAttribs() const

--- a/kadas/gui/mapitems/kadasrectangleitembase.h
+++ b/kadas/gui/mapitems/kadasrectangleitembase.h
@@ -34,10 +34,10 @@ class KADAS_GUI_EXPORT KadasRectangleItemBase : public KadasMapItem SIP_ABSTRACT
     bool positionLocked() const { return mPosLocked; }
     void setPositionLocked( bool locked );
 
-    KadasItemRect boundingBox() const override;
+    QgsRectangle boundingBox() const override;
     Margin margin() const override;
     QList<KadasMapItem::Node> nodes( const QgsMapSettings &settings ) const override;
-    bool intersects( const KadasMapRect &rect, const QgsMapSettings &settings, bool contains = false ) const override;
+    bool intersects( const QgsRectangle &rect, const QgsMapSettings &settings, bool contains = false ) const override;
     void render( QgsRenderContext &context ) const override;
 
     bool startPart( const KadasMapPos &firstPoint, const QgsMapSettings &mapSettings ) override;

--- a/kadas/gui/mapitems/kadasselectionrectitem.cpp
+++ b/kadas/gui/mapitems/kadasselectionrectitem.cpp
@@ -31,13 +31,13 @@
 QJsonObject KadasSelectionRectItem::State::serialize() const
 {
   QJsonObject json;
-  json["status"] = static_cast<int>( drawStatus );
+  //json["status"] = static_cast<int>( drawStatus );
   return json;
 }
 
 bool KadasSelectionRectItem::State::deserialize( const QJsonObject &json )
 {
-  drawStatus = static_cast<DrawStatus>( json["status"].toInt() );
+  //drawStatus = static_cast<DrawStatus>( json["status"].toInt() );
   return true;
 }
 
@@ -54,7 +54,7 @@ void KadasSelectionRectItem::setSelectedItems( const QList<KadasMapItem *> &item
   update();
 }
 
-KadasItemRect KadasSelectionRectItem::boundingBox() const
+QgsRectangle KadasSelectionRectItem::boundingBox() const
 {
   if ( mItems.isEmpty() )
   {
@@ -70,7 +70,7 @@ KadasItemRect KadasSelectionRectItem::boundingBox() const
     rect.setXMaximum( std::max( rect.xMaximum(), itemRect.xMaximum() ) );
     rect.setYMaximum( std::max( rect.yMaximum(), itemRect.yMaximum() ) );
   }
-  return KadasItemRect( rect.xMinimum(), rect.yMinimum(), rect.xMaximum(), rect.yMaximum() );
+  return rect;
 }
 
 KadasMapItem::Margin KadasSelectionRectItem::margin() const
@@ -117,7 +117,7 @@ KadasMapRect KadasSelectionRectItem::itemsRect( const QgsCoordinateReferenceSyst
   return rect;
 }
 
-bool KadasSelectionRectItem::intersects( const KadasMapRect &rect, const QgsMapSettings &settings, bool contains ) const
+bool KadasSelectionRectItem::intersects( const QgsRectangle &rect, const QgsMapSettings &settings, bool contains ) const
 {
   if ( mItems.isEmpty() )
   {

--- a/kadas/gui/mapitems/kadasselectionrectitem.h
+++ b/kadas/gui/mapitems/kadasselectionrectitem.h
@@ -31,10 +31,10 @@ class KADAS_GUI_EXPORT KadasSelectionRectItem : public KadasMapItem
 
     QString itemName() const override { return tr( "Selection" ); }
 
-    KadasItemRect boundingBox() const override;
+    QgsRectangle boundingBox() const override;
     Margin margin() const override;
     QList<KadasMapItem::Node> nodes( const QgsMapSettings &settings ) const override { return QList<KadasMapItem::Node>(); }
-    bool intersects( const KadasMapRect &rect, const QgsMapSettings &settings, bool contains = false ) const override;
+    bool intersects( const QgsRectangle &rect, const QgsMapSettings &settings, bool contains = false ) const override;
     void render( QgsRenderContext &context ) const override;
 #ifndef SIP_RUN
     QString asKml( const QgsRenderContext &context, QuaZip *kmzZip = nullptr ) const override { return QString(); }

--- a/kadas/gui/mapitems/kadassymbolitem.cpp
+++ b/kadas/gui/mapitems/kadassymbolitem.cpp
@@ -109,7 +109,7 @@ void KadasSymbolItem::setState( const KadasMapItem::State *state )
 
 void KadasSymbolItem::render( QgsRenderContext &context ) const
 {
-  if ( constState()->drawStatus == State::DrawStatus::Empty )
+  if ( mDrawStatus == DrawStatus::Empty )
   {
     return;
   }

--- a/kadas/gui/mapitems/kadastextitem.h
+++ b/kadas/gui/mapitems/kadastextitem.h
@@ -17,54 +17,63 @@
 #ifndef KADASTEXTITEM_H
 #define KADASTEXTITEM_H
 
-#include "kadas/gui/mapitems/kadasrectangleitembase.h"
+#include <qgis/qgsannotationpointtextitem.h>
+
+#include "kadas/gui/mapitems/kadaspointitem.h"
 
 
-class KADAS_GUI_EXPORT KadasTextItem : public KadasRectangleItemBase
+class KADAS_GUI_EXPORT KadasTextItem : public KadasAbstractPointItem
 {
     Q_OBJECT
     Q_PROPERTY( QString text READ text WRITE setText )
-    Q_PROPERTY( QColor outlineColor READ outlineColor WRITE setOutlineColor )
-    Q_PROPERTY( QColor fillColor READ fillColor WRITE setFillColor )
+    Q_PROPERTY( QColor color READ color WRITE setColor )
     Q_PROPERTY( QFont font READ font WRITE setFont )
-    Q_PROPERTY( bool frameAutoResize READ frameAutoResize WRITE setFrameAutoResize )
 
   public:
     KadasTextItem( const QgsCoordinateReferenceSystem &crs );
 
     QString itemName() const override { return tr( "Text" ); }
 
+    virtual void setItemGeometry( const QgsPointXY &point ) override;
+
+    virtual QgsAnnotationPointTextItem *annotationItem( const QgsCoordinateReferenceSystem &crs = QgsCoordinateReferenceSystem() ) const override SIP_FACTORY;
+
     void setText( const QString &text );
     const QString &text() const { return mText; }
-    void setFillColor( const QColor &c );
-    QColor fillColor() const { return mFillColor; }
-    void setOutlineColor( const QColor &c );
-    QColor outlineColor() const { return mOutlineColor; }
+
+    void setColor( const QColor &color );
+    QColor color() const { return mColor; }
+
     void setFont( const QFont &font );
     const QFont &font() const { return mFont; }
-    void setFrameAutoResize( bool frameAutoResize );
-    bool frameAutoResize() const { return mFrameAutoResize; }
-    void setAngle( double angle );
 
-    QImage symbolImage() const override;
+    virtual QgsRectangle boundingBox() const override;
+    virtual void render( QgsRenderContext &context ) const override;
+
+
+    // virtual EditContext getEditContext(const KadasMapPos &pos, const QgsMapSettings &mapSettings) const override;
+    // virtual void edit(const EditContext &context, const KadasMapPos &newPoint, const QgsMapSettings &mapSettings) override;
+    // virtual void edit(const EditContext &context, const AttribValues &values, const QgsMapSettings &mapSettings) override;
+    // virtual AttribValues editAttribsFromPosition(const EditContext &context, const KadasMapPos &pos, const QgsMapSettings &mapSettings) const override;
+    // virtual KadasMapPos positionFromEditAttribs(const EditContext &context, const AttribValues &values, const QgsMapSettings &mapSettings) const override;
 
 #ifndef SIP_RUN
     QString asKml( const QgsRenderContext &context, QuaZip *kmzZip = nullptr ) const override;
 #endif
 
-  private:
-    QString mText;
-    QColor mOutlineColor;
-    QColor mFillColor;
-    QFont mFont;
-    bool mFrameAutoResize = true;
-
-    KadasMapItem *_clone() const override SIP_FACTORY { return new KadasTextItem( crs() ); }
-
   protected:
-    virtual void renderPrivate( QgsRenderContext &context, const QPointF &center, const QRect &rect, double dpiScale ) const override;
-    virtual void editPrivate( const KadasMapPos &newPoint, const QgsMapSettings &mapSettings ) override;
-    void populateContextMenuPrivate( QMenu *menu, const EditContext &context, const KadasMapPos &clickPos, const QgsMapSettings &mapSettings ) override;
+    virtual KadasMapItem *_clone() const override;
+    virtual void writeXmlPrivate( QDomElement &element ) const override;
+    virtual void readXmlPrivate( const QDomElement &element ) override;
+
+  private:
+    void updateQgsAnnotation() override;
+
+    QgsAnnotationPointTextItem *mQgsItem = nullptr;
+
+    QString mText;
+    QColor mColor;
+    QFont mFont;
 };
 
 #endif // KADASTEXTITEM_H

--- a/kadas/gui/maptools/kadasmaptoolcreateitem.h
+++ b/kadas/gui/maptools/kadasmaptoolcreateitem.h
@@ -51,7 +51,7 @@ class KADAS_GUI_EXPORT KadasMapToolCreateItem : public QgsMapTool
     void keyPressEvent( QKeyEvent *e ) override;
 
     const KadasMapItem *currentItem() const { return mItem; }
-    KadasMapItem *takeItem();
+    // KadasMapItem *takeItem();
     const KadasMapItemEditor *currentEditor() const { return mEditor; }
 
     void setMultipart( bool multipart ) { mMultipart = multipart; }
@@ -141,21 +141,17 @@ class KADAS_GUI_EXPORT KadasMapToolCreateItem : public QgsMapTool
     KadasMapItem *mItem = nullptr;
     KadasItemLayer *mLayer = nullptr;
 
-    struct ItemData
-    {
-        KadasItemLayer::ItemId itemId = KadasItemLayer::ITEM_ID_NULL;
-        QMap<QString, QVariant> props;
-    };
     struct ToolState : KadasStateHistory::State
     {
-        ToolState( State *_itemState, QSharedPointer<ItemData> _itemData )
-          : itemState( _itemState ), itemData( _itemData ) {}
+        ToolState( KadasMapItem *item, KadasItemLayer::ItemId itemId = KadasItemLayer::ITEM_ID_NULL )
+          : itemState( item )
+          , itemId( itemId ) {}
         ~ToolState() { delete itemState; }
-        State *itemState = nullptr;
-        QSharedPointer<ItemData> itemData;
+        KadasMapItem *itemState = nullptr;
+        KadasItemLayer::ItemId itemId = KadasItemLayer::ITEM_ID_NULL;
     };
     KadasStateHistory *mStateHistory = nullptr;
-    QSharedPointer<ItemData> mCurrentItemData;
+    KadasItemLayer::ItemId mCurrentItemId = KadasItemLayer::ITEM_ID_NULL;
 
     KadasFloatingInputWidget *mInputWidget = nullptr;
     KadasMapItem::AttribDefs mDrawAttribs;
@@ -182,7 +178,6 @@ class KADAS_GUI_EXPORT KadasMapToolCreateItem : public QgsMapTool
     void acceptInput();
     void stateChanged( KadasStateHistory::ChangeType changeType, KadasStateHistory::State *state, KadasStateHistory::State *prevState );
     void setTargetLayer( QgsMapLayer *layer );
-    void storeItemProps();
 };
 
 #endif // KADASMAPTOOLCREATEITEM_H

--- a/kadas/gui/maptools/kadasmaptooledititem.cpp
+++ b/kadas/gui/maptools/kadasmaptooledititem.cpp
@@ -64,7 +64,7 @@ void KadasMapToolEditItem::activate()
   QgsMapTool::activate();
   setCursor( Qt::ArrowCursor );
   mStateHistory = new KadasStateHistory( this );
-  mStateHistory->push( mItem->constState()->clone() );
+  mStateHistory->push( new ToolState( mItem->clone() ) );
   connect( mStateHistory, &KadasStateHistory::stateChanged, this, &KadasMapToolEditItem::stateChanged );
 
   mSnapping = QgsSettings().value( "/kadas/snapping_enabled", false ).toBool();

--- a/kadas/gui/maptools/kadasmaptooledititem.h
+++ b/kadas/gui/maptools/kadasmaptooledititem.h
@@ -46,6 +46,14 @@ class KADAS_GUI_EXPORT KadasMapToolEditItem : public QgsMapTool
     void keyPressEvent( QKeyEvent *e ) override;
 
   private:
+    struct ToolState : KadasStateHistory::State
+    {
+        ToolState( KadasMapItem *item )
+          : itemState( item ) {}
+        ~ToolState() { delete itemState; }
+        KadasMapItem *itemState = nullptr;
+    };
+
     KadasStateHistory *mStateHistory = nullptr;
     KadasBottomBar *mBottomBar = nullptr;
     KadasItemLayer *mLayer = nullptr;

--- a/kadas/gui/maptools/kadasmaptooledititemgroup.h
+++ b/kadas/gui/maptools/kadasmaptooledititemgroup.h
@@ -47,6 +47,7 @@ class KADAS_GUI_EXPORT KadasMapToolEditItemGroup : public QgsMapTool
     QList<KadasMapItem *> mItems;
     KadasItemLayer *mLayer;
     QgsPointXY mMoveRefPos;
+    QgsPointXY mMoveRefPos2;
     QList<QgsPointXY> mItemRefPos;
     KadasBottomBar *mBottomBar = nullptr;
     QLabel *mStatusLabel = nullptr;

--- a/kadas/gui/maptools/kadasmaptoolheightprofile.cpp
+++ b/kadas/gui/maptools/kadasmaptoolheightprofile.cpp
@@ -40,9 +40,9 @@ KadasMapToolHeightProfile::KadasMapToolHeightProfile( QgsMapCanvas *canvas )
   setSelectItems( false );
   setToolLabel( tr( "Measure height profile" ) );
 
-  mPosMarker = new KadasPointItem( canvas->mapSettings().destinationCrs(), KadasPointItem::IconType::ICON_CIRCLE );
-  mPosMarker->setIconFill( Qt::blue );
-  mPosMarker->setIconOutline( QPen( Qt::blue ) );
+  mPosMarker = new KadasPointItem( canvas->mapSettings().destinationCrs(), Qgis::MarkerShape::Circle );
+  mPosMarker->setColor( Qt::blue );
+  mPosMarker->setStrokeColor( Qt::blue );
   mPosMarker->setZIndex( 100 );
   KadasMapCanvasItemManager::instance()->addItem( mPosMarker );
 
@@ -91,7 +91,7 @@ void KadasMapToolHeightProfile::setMarkerPos( double distance )
       double k = distance / segDist;
       double x = points[i].x() + ( points[i + 1].x() - points[i].x() ) * k;
       double y = points[i].y() + ( points[i + 1].y() - points[i].y() ) * k;
-      mPosMarker->setPosition( KadasItemPos( x, y ) );
+      mPosMarker->setPoint( QgsPoint( x, y ) );
       return;
     }
     else
@@ -99,7 +99,7 @@ void KadasMapToolHeightProfile::setMarkerPos( double distance )
       distance -= segDist;
     }
   }
-  mPosMarker->setPosition( points.last() );
+  mPosMarker->setPoint( points.last() );
 }
 
 void KadasMapToolHeightProfile::pickLine()
@@ -121,7 +121,7 @@ void KadasMapToolHeightProfile::canvasMoveEvent( QgsMapMouseEvent *e )
   if ( !mPicking )
   {
     const KadasLineItem *lineItem = dynamic_cast<const KadasLineItem *>( currentItem() );
-    if ( lineItem && lineItem->constState()->drawStatus == KadasMapItem::State::DrawStatus::Finished && !lineItem->constState()->points.isEmpty() )
+    if ( lineItem && lineItem->drawStatus() == KadasMapItem::DrawStatus::Finished && !lineItem->constState()->points.isEmpty() )
     {
       QgsPointXY p = toMapCoordinates( e->pos() );
       const QList<KadasItemPos> &points = lineItem->constState()->points.front();
@@ -144,7 +144,7 @@ void KadasMapToolHeightProfile::canvasMoveEvent( QgsMapMouseEvent *e )
       }
       if ( std::sqrt( minDist ) / mCanvas->mapSettings().mapUnitsPerPixel() < 30. )
       {
-        mPosMarker->setPosition( KadasItemPos::fromPoint( minPos ) );
+        mPosMarker->setPoint( minPos );
         mDialog->setMarkerPos( minIdx, minPos, mCanvas->mapSettings().destinationCrs() );
       }
     }
@@ -204,7 +204,7 @@ void KadasMapToolHeightProfile::drawFinished()
       mDialog->setPoints( points, lineItem->crs() );
       QgsPoint markerPos( points[0] );
       mPosMarker->clear();
-      mPosMarker->addPartFromGeometry( markerPos );
+      mPosMarker->setPoint( markerPos );
     }
   }
 }

--- a/kadas/gui/maptools/kadasmaptoolminmax.cpp
+++ b/kadas/gui/maptools/kadasmaptoolminmax.cpp
@@ -282,7 +282,7 @@ void KadasMapToolMinMax::canvasPressEvent( QgsMapMouseEvent *e )
   {
     return;
   }
-  if ( currentItem() && currentItem()->constState()->drawStatus != KadasMapItem::State::DrawStatus::Drawing && mPinMin && mPinMax )
+  if ( currentItem() && currentItem()->drawStatus() != KadasMapItem::DrawStatus::Drawing && mPinMin && mPinMax )
   {
     QgsPointXY mapPos = toMapCoordinates( e->pos() );
     if ( mPinMax->hitTest( KadasMapPos::fromPoint( mapPos ), mCanvas->mapSettings() ) )

--- a/kadas/gui/milx/kadasmilxeditor.cpp
+++ b/kadas/gui/milx/kadasmilxeditor.cpp
@@ -97,7 +97,7 @@ void KadasMilxEditor::symbolSelected( const KadasMilxSymbolDesc &symbolTemplate 
     mSymbolButton->setText( tr( "Select..." ) );
   }
   mSelectedSymbol = symbolTemplate;
-  if ( dynamic_cast<KadasMilxItem *>( mItem ) && mItem->constState()->drawStatus == KadasMapItem::State::DrawStatus::Empty )
+  if ( dynamic_cast<KadasMilxItem *>( mItem ) && mItem->drawStatus() == KadasMapItem::DrawStatus::Empty )
   {
     static_cast<KadasMilxItem *>( mItem )->setSymbol( symbolTemplate );
   }

--- a/kadas/gui/milx/kadasmilxitem.h
+++ b/kadas/gui/milx/kadasmilxitem.h
@@ -51,12 +51,12 @@ class KADAS_GUI_EXPORT KadasMilxItem : public KadasMapItem
     QImage symbolImage() const override;
     QPointF symbolAnchor() const override { return mSymbolAnchor; }
 
-    KadasItemRect boundingBox() const override;
+    QgsRectangle boundingBox() const override;
     Margin margin() const override;
 
     QList<KadasMapItem::Node> nodes( const QgsMapSettings &settings ) const override;
 
-    bool intersects( const KadasMapRect &rect, const QgsMapSettings &settings, bool contains = false ) const override;
+    bool intersects( const QgsRectangle &rect, const QgsMapSettings &settings, bool contains = false ) const override;
     bool hitTest( const KadasMapPos &pos, const QgsMapSettings &settings ) const override;
     QPair<KadasMapPos, double> closestPoint( const KadasMapPos &pos, const QgsMapSettings &settings ) const override;
 

--- a/kadas/gui/ui/kadasredliningtexteditor.ui
+++ b/kadas/gui/ui/kadasredliningtexteditor.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>392</width>
-    <height>55</height>
+    <height>68</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -67,7 +67,7 @@
    <item row="1" column="2">
     <widget class="QPushButton" name="mPushButtonBold">
      <property name="icon">
-      <iconset resource="../../resources/resources.qrc">
+      <iconset>
        <normaloff>:/kadas/icons/textBold</normaloff>:/kadas/icons/textBold</iconset>
      </property>
      <property name="checkable">
@@ -78,7 +78,7 @@
    <item row="1" column="3">
     <widget class="QPushButton" name="mPushButtonItalic">
      <property name="icon">
-      <iconset resource="../../resources/resources.qrc">
+      <iconset>
        <normaloff>:/kadas/icons/textItalic</normaloff>:/kadas/icons/textItalic</iconset>
      </property>
      <property name="checkable">
@@ -89,7 +89,7 @@
    <item row="0" column="1" colspan="3">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
-      <widget class="QLabel" name="mLabelFillColor">
+      <widget class="QLabel" name="mLabelColor">
        <property name="minimumSize">
         <size>
          <width>0</width>
@@ -102,42 +102,7 @@
       </widget>
      </item>
      <item>
-      <widget class="QgsColorButton" name="mToolButtonFillColor">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>32</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>48</width>
-         <height>16777215</height>
-        </size>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="mLabelBorderColor">
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>Outline:</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QgsColorButton" name="mToolButtonBorderColor">
+      <widget class="QgsColorButton" name="mToolButtonColor">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
          <horstretch>0</horstretch>
@@ -172,15 +137,12 @@
  </customwidgets>
  <tabstops>
   <tabstop>mLineEditText</tabstop>
-  <tabstop>mToolButtonFillColor</tabstop>
-  <tabstop>mToolButtonBorderColor</tabstop>
+  <tabstop>mToolButtonColor</tabstop>
   <tabstop>mFontComboBox</tabstop>
   <tabstop>mSpinBoxSize</tabstop>
   <tabstop>mPushButtonBold</tabstop>
   <tabstop>mPushButtonItalic</tabstop>
  </tabstops>
- <resources>
-  <include location="../../resources/resources.qrc"/>
- </resources>
+ <resources/>
  <connections/>
 </ui>

--- a/python/kadasgui/auto_additions/kadasmapitem.py
+++ b/python/kadasgui/auto_additions/kadasmapitem.py
@@ -1,15 +1,9 @@
 # The following has been generated automatically from kadas/gui/mapitems/kadasmapitem.h
 # monkey patching scoped based enum
-KadasMapItem.State.Empty = KadasMapItem.State.DrawStatus.Empty
-KadasMapItem.State.Empty.is_monkey_patched = True
-KadasMapItem.State.DrawStatus.Empty.__doc__ = ""
-KadasMapItem.State.Drawing = KadasMapItem.State.DrawStatus.Drawing
-KadasMapItem.State.Drawing.is_monkey_patched = True
-KadasMapItem.State.DrawStatus.Drawing.__doc__ = ""
-KadasMapItem.State.Finished = KadasMapItem.State.DrawStatus.Finished
-KadasMapItem.State.Finished.is_monkey_patched = True
-KadasMapItem.State.DrawStatus.Finished.__doc__ = ""
-KadasMapItem.State.DrawStatus.__doc__ = """
+KadasMapItem.DrawStatus.Empty.__doc__ = ""
+KadasMapItem.DrawStatus.Drawing.__doc__ = ""
+KadasMapItem.DrawStatus.Finished.__doc__ = ""
+KadasMapItem.DrawStatus.__doc__ = """
 
 * ``Empty``: 
 * ``Drawing``: 
@@ -17,6 +11,7 @@ KadasMapItem.State.DrawStatus.__doc__ = """
 
 """
 # --
+KadasMapItem.DrawStatus.baseClass = KadasMapItem
 # monkey patching scoped based enum
 KadasMapItem.NumericAttribute.TypeCoordinate = KadasMapItem.NumericAttribute.Type.TypeCoordinate
 KadasMapItem.NumericAttribute.TypeCoordinate.is_monkey_patched = True
@@ -67,6 +62,7 @@ try:
     KadasMapItem.anchorNodeRenderer = staticmethod(KadasMapItem.anchorNodeRenderer)
     KadasMapItem.outputDpiScale = staticmethod(KadasMapItem.outputDpiScale)
     KadasMapItem.getTextRenderScale = staticmethod(KadasMapItem.getTextRenderScale)
+    KadasMapItem.__signal_arguments__ = {'zIndexChanged': ['index: int']}
 except AttributeError:
     pass
 try:

--- a/python/kadasgui/auto_generated/3d/kadasmapitemlayer3drenderer.sip.in
+++ b/python/kadasgui/auto_generated/3d/kadasmapitemlayer3drenderer.sip.in
@@ -1,0 +1,152 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * kadas/gui/3d/kadasmapitemlayer3drenderer.h                           *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.py again   *
+ ************************************************************************/
+
+
+
+
+
+
+// this is needed for the "convert to subclass" code below to compile
+%ModuleHeaderCode
+#include "kadas/gui/3d/kadasmapitemlayer3drenderer.h"
+%End
+
+
+
+  class KadasMapItemLayer3DRendererMetadata : Qgs3DRendererAbstractMetadata
+{
+%Docstring(signature="appended")
+Metadata for annotation layer 3D renderer to allow creation of its instances from XML.
+
+.. warning::
+
+   This is not considered stable API, and may change in future QGIS releases. It is
+   exposed to the Python bindings as a tech preview only.
+
+.. versionadded:: 4.0
+%End
+
+%TypeHeaderCode
+#include "kadas/gui/3d/kadasmapitemlayer3drenderer.h"
+%End
+  public:
+    KadasMapItemLayer3DRendererMetadata();
+
+    virtual QgsAbstract3DRenderer *createRenderer( QDomElement &elem, const QgsReadWriteContext &context ) /Factory/;
+
+%Docstring
+Creates an instance of a 3D renderer based on a DOM element with renderer configuration
+%End
+};
+
+class KadasMapItemLayer3DRenderer : QgsAbstract3DRenderer
+{
+%Docstring(signature="appended")
+3D renderers for annotation layers.
+
+.. versionadded:: 4.0
+%End
+
+%TypeHeaderCode
+#include "kadas/gui/3d/kadasmapitemlayer3drenderer.h"
+%End
+%ConvertToSubClassCode
+    if ( dynamic_cast<KadasMapItemLayer3DRenderer *>( sipCpp ) != nullptr )
+      sipType = sipType_KadasMapItemLayer3DRenderer;
+    else
+      sipType = nullptr;
+%End
+  public:
+    KadasMapItemLayer3DRenderer();
+
+    void setLayer( KadasItemLayer *layer );
+
+
+    virtual QString type() const;
+
+    virtual KadasMapItemLayer3DRenderer *clone() const /Factory/;
+
+
+    virtual void writeXml( QDomElement &elem, const QgsReadWriteContext &context ) const;
+
+    virtual void readXml( const QDomElement &elem, const QgsReadWriteContext &context );
+
+    virtual void resolveReferences( const QgsProject &project );
+
+
+    Qgis::AltitudeClamping altitudeClamping() const;
+%Docstring
+Returns the altitude clamping method, which determines the vertical position of annotations.
+
+.. seealso:: :py:func:`setAltitudeClamping`
+%End
+
+    void setAltitudeClamping( Qgis::AltitudeClamping clamping );
+%Docstring
+Sets the altitude ``clamping`` method, which determines the vertical position of annotations.
+
+.. seealso:: :py:func:`altitudeClamping`
+%End
+
+    double zOffset() const;
+%Docstring
+Returns the z offset, which is a fixed offset amount which should be added to z values for the annotations.
+
+.. seealso:: :py:func:`setZOffset`
+%End
+
+    void setZOffset( double offset );
+%Docstring
+Sets the z ``offset``, which is a fixed offset amount which will be added to z values for the annotations.
+
+.. seealso:: :py:func:`zOffset`
+%End
+
+    bool showCalloutLines() const;
+%Docstring
+Returns ``True`` if callout lines are shown, vertically joining the annotations to the terrain.
+
+.. seealso:: :py:func:`setShowCalloutLines`
+%End
+
+    void setShowCalloutLines( bool show );
+%Docstring
+Sets whether callout lines are shown, vertically joining the annotations to the terrain.
+
+.. seealso:: :py:func:`showCalloutLines`
+%End
+
+
+
+
+
+    QgsTextFormat textFormat() const;
+%Docstring
+Returns the text format to use for rendering text annotations in 3D.
+
+.. seealso:: :py:func:`setTextFormat`
+%End
+
+    void setTextFormat( const QgsTextFormat &format );
+%Docstring
+Sets the text ``format`` to use for rendering text annotations in 3D.
+
+.. seealso:: :py:func:`textFormat`
+%End
+
+  private:
+    KadasMapItemLayer3DRenderer( const KadasMapItemLayer3DRenderer & );
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * kadas/gui/3d/kadasmapitemlayer3drenderer.h                           *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.py again   *
+ ************************************************************************/

--- a/python/kadasgui/auto_generated/kadasitemlayer.sip.in
+++ b/python/kadasgui/auto_generated/kadasitemlayer.sip.in
@@ -126,6 +126,11 @@ class KadasItemLayer : KadasPluginLayer
       PICK_OBJECTIVE_TOOLTIP
     };
 
+    QgsAnnotationLayer *qgisAnnotationLayer( const QgsCoordinateReferenceSystem &crs ) const /Factory/;
+%Docstring
+The QGIS annotation layer will only contain items/annotations inheriting from :py:class:`QgsAnnotationItem`.
+%End
+
     static QString layerType();
     KadasItemLayer( const QString &name, const QgsCoordinateReferenceSystem &crs );
     ~KadasItemLayer();

--- a/python/kadasgui/auto_generated/mapitems/kadasanchoreditem.sip.in
+++ b/python/kadasgui/auto_generated/mapitems/kadasanchoreditem.sip.in
@@ -34,13 +34,13 @@ the Free Software Foundation; either version 2 of the License, or     *
     double anchorY() const;
     void setAnchorY( double anchorY );
 
-    virtual KadasItemRect boundingBox() const;
+    virtual QgsRectangle boundingBox() const;
 
     virtual Margin margin() const;
 
     virtual QList<KadasMapItem::Node> nodes( const QgsMapSettings &settings ) const;
 
-    virtual bool intersects( const KadasMapRect &rect, const QgsMapSettings &settings, bool contains = false ) const;
+    virtual bool intersects( const QgsRectangle &rect, const QgsMapSettings &settings, bool contains = false ) const;
 
 
     virtual bool startPart( const KadasMapPos &firstPoint, const QgsMapSettings &mapSettings );

--- a/python/kadasgui/auto_generated/mapitems/kadascircleitem.sip.in
+++ b/python/kadasgui/auto_generated/mapitems/kadascircleitem.sip.in
@@ -95,6 +95,7 @@ the Free Software Foundation; either version 2 of the License, or     *
 
   protected:
     virtual KadasMapItem *_clone() const /Factory/;
+
     virtual State *createEmptyState() const /Factory/;
     virtual void recomputeDerived();
 

--- a/python/kadasgui/auto_generated/mapitems/kadascircularsectoritem.sip.in
+++ b/python/kadasgui/auto_generated/mapitems/kadascircularsectoritem.sip.in
@@ -106,6 +106,7 @@ the Free Software Foundation; either version 2 of the License, or     *
 
   protected:
     virtual KadasMapItem *_clone() const /Factory/;
+
     virtual State *createEmptyState() const /Factory/;
     virtual void recomputeDerived();
 

--- a/python/kadasgui/auto_generated/mapitems/kadascoordinatecrossitem.sip.in
+++ b/python/kadasgui/auto_generated/mapitems/kadascoordinatecrossitem.sip.in
@@ -30,13 +30,13 @@ the Free Software Foundation; either version 2 of the License, or     *
 
     virtual QString itemName() const;
 
-    virtual KadasItemRect boundingBox() const;
+    virtual QgsRectangle boundingBox() const;
 
     virtual Margin margin() const;
 
     virtual QList<KadasMapItem::Node> nodes( const QgsMapSettings &settings ) const;
 
-    virtual bool intersects( const KadasMapRect &rect, const QgsMapSettings &settings, bool contains = false ) const;
+    virtual bool intersects( const QgsRectangle &rect, const QgsMapSettings &settings, bool contains = false ) const;
 
     virtual void render( QgsRenderContext &context ) const;
 

--- a/python/kadasgui/auto_generated/mapitems/kadasgeometryitem.sip.in
+++ b/python/kadasgui/auto_generated/mapitems/kadasgeometryitem.sip.in
@@ -44,13 +44,13 @@ the Free Software Foundation; either version 2 of the License, or     *
     KadasGeometryItem( const QgsCoordinateReferenceSystem &crs );
     ~KadasGeometryItem();
 
-    virtual KadasItemRect boundingBox() const;
+    virtual QgsRectangle boundingBox() const;
 
     virtual Margin margin() const;
 
     virtual QList<KadasMapItem::Node> nodes( const QgsMapSettings &settings ) const;
 
-    virtual bool intersects( const KadasMapRect &rect, const QgsMapSettings &settings, bool contains = false ) const;
+    virtual bool intersects( const QgsRectangle &rect, const QgsMapSettings &settings, bool contains = false ) const;
 
     virtual QPair<KadasMapPos, double> closestPoint( const KadasMapPos &pos, const QgsMapSettings &settings ) const;
 

--- a/python/kadasgui/auto_generated/mapitems/kadaslineitem.sip.in
+++ b/python/kadasgui/auto_generated/mapitems/kadaslineitem.sip.in
@@ -109,6 +109,7 @@ the Free Software Foundation; either version 2 of the License, or     *
 
   protected:
     virtual KadasMapItem *_clone() const /Factory/;
+
     virtual State *createEmptyState() const /Factory/;
     virtual void recomputeDerived();
 

--- a/python/kadasgui/auto_generated/mapitems/kadasmapitem.sip.in
+++ b/python/kadasgui/auto_generated/mapitems/kadasmapitem.sip.in
@@ -233,11 +233,25 @@ class KadasMapItem : QObject /Abstract/
 #include "kadas/gui/mapitems/kadasmapitem.h"
 %End
   public:
+    enum class DrawStatus
+    {
+      Empty,
+      Drawing,
+      Finished
+    };
+
     KadasMapItem( const QgsCoordinateReferenceSystem &crs );
     ~KadasMapItem();
     KadasMapItem *clone() const;
     QJsonObject serialize() const;
     bool deserialize( const QJsonObject &json );
+
+    virtual bool useQgisAnnotations() const;
+
+    virtual QgsAnnotationItem *annotationItem( const QgsCoordinateReferenceSystem &crs = QgsCoordinateReferenceSystem() ) const /Factory/;
+%Docstring
+Returns the :py:class:`QgsAnnotationItem` in the given crs (if not specified, no transformation occurs)
+%End
 
     virtual QString itemName() const = 0;
     virtual QString exportName() const;
@@ -247,7 +261,7 @@ class KadasMapItem : QObject /Abstract/
 The item crs */
 %End
 
-    virtual KadasItemRect boundingBox() const = 0;
+    virtual QgsRectangle boundingBox() const = 0;
 %Docstring
 Bounding box in geographic coordinates */
 %End
@@ -269,7 +283,7 @@ Bounding box in geographic coordinates */
 
     virtual QList<KadasMapItem::Node> nodes( const QgsMapSettings &settings ) const = 0;
 
-    virtual bool intersects( const KadasMapRect &rect, const QgsMapSettings &settings, bool contains = false ) const = 0;
+    virtual bool intersects( const QgsRectangle &rect, const QgsMapSettings &settings, bool contains = false ) const = 0;
 %Docstring
 Hit test, rect in item crs */
 %End
@@ -285,6 +299,9 @@ Return the item point to the specified one */
 Render the item */
 %End
 
+
+    DrawStatus drawStatus() const;
+    void setDrawStatus( DrawStatus status );
 
     void associateToLayer( QgsMapLayer *layer );
 %Docstring
@@ -316,11 +333,6 @@ symbol scale */
 %End
     double symbolScale() const;
 
-    void setAuthId( const QString &authId );
-%Docstring
-authid */
-%End
-    QString authId() const;
 
     void setTooltip( const QString &tooltip );
 %Docstring
@@ -350,14 +362,6 @@ Trigger a redraw */
 #include "kadas/gui/mapitems/kadasmapitem.h"
 %End
       public:
-        enum class DrawStatus
-        {
-          Empty,
-          Drawing,
-          Finished
-        };
-
-        DrawStatus drawStatus;
         virtual void assign( const State *other ) = 0;
         virtual State *clone() const = 0 /Factory/;
         virtual QJsonObject serialize() const = 0;
@@ -437,8 +441,16 @@ Trigger a redraw */
     void setEditor( const QString &editor );
     const QString &editor() const;
 
-    virtual KadasItemPos position() const = 0;
-    virtual void setPosition( const KadasItemPos &pos ) = 0;
+    virtual KadasItemPos position() const;
+%Docstring
+Once every item has been migrated this should be dropped
+%End
+    virtual void setPosition( const KadasItemPos &pos );
+
+    virtual void translate( double dx, double dy );
+%Docstring
+Once every item has been migrated this should become pure virtual
+%End
 
 
     QDomElement writeXml( QDomDocument &document ) const;
@@ -453,10 +465,15 @@ Trigger a redraw */
     void aboutToBeDestroyed();
     void changed();
     void propertyChanged();
+    void zIndexChanged( int index );
 
   protected:
 
-    virtual KadasMapItem::State *createEmptyState() const = 0 /Factory/;
+
+    virtual KadasMapItem::State *createEmptyState() const /Factory/;
+
+    virtual void writeXmlPrivate( QDomElement &element ) const;
+    virtual void readXmlPrivate( const QDomElement &element );
 
     static void defaultNodeRenderer( QPainter *painter, const QPointF &screenPoint, int nodeSize );
     static void anchorNodeRenderer( QPainter *painter, const QPointF &screenPoint, int nodeSize );
@@ -464,8 +481,9 @@ Trigger a redraw */
     static double getTextRenderScale( const QgsRenderContext &context );
 
     KadasMapPos toMapPos( const KadasItemPos &itemPos, const QgsMapSettings &settings ) const;
+    QgsPointXY toMapPos( const QgsPointXY &itemPos, const QgsMapSettings &settings ) const;
     KadasItemPos toItemPos( const KadasMapPos &mapPos, const QgsMapSettings &settings ) const;
-    KadasMapRect toMapRect( const KadasItemRect &itemRect, const QgsMapSettings &settings ) const;
+    QgsRectangle toMapRect( const QgsRectangle &itemRect, const QgsMapSettings &settings ) const;
     KadasItemRect toItemRect( const KadasMapRect &itemRect, const QgsMapSettings &settings ) const;
     double pickTolSqr( const QgsMapSettings &settings ) const;
     double pickTol( const QgsMapSettings &settings ) const;

--- a/python/kadasgui/auto_generated/mapitems/kadaspointitem.sip.in
+++ b/python/kadasgui/auto_generated/mapitems/kadaspointitem.sip.in
@@ -9,7 +9,11 @@
 
 
 
-class KadasPointItem : KadasGeometryItem
+
+
+
+
+class KadasAbstractPointItem : KadasMapItem /Abstract/
 {
 %Docstring(signature="appended")
 *************************************************************************
@@ -26,9 +30,15 @@ the Free Software Foundation; either version 2 of the License, or     *
 #include "kadas/gui/mapitems/kadaspointitem.h"
 %End
   public:
-    KadasPointItem( const QgsCoordinateReferenceSystem &crs, KadasGeometryItem::IconType icon = KadasGeometryItem::IconType::ICON_CIRCLE );
+    KadasAbstractPointItem( const QgsCoordinateReferenceSystem &crs );
 
-    virtual QString itemName() const;
+    virtual QgsPointXY point() const;
+    virtual void setPoint( const QgsPointXY &point );
+
+    virtual void setItemGeometry( const QgsPointXY &point ) = 0;
+
+    virtual void translate( double dx, double dy );
+    virtual void setState( const KadasMapItem::State *state );
 
     virtual bool startPart( const KadasMapPos &firstPoint, const QgsMapSettings &mapSettings );
 
@@ -43,12 +53,9 @@ the Free Software Foundation; either version 2 of the License, or     *
     virtual void endPart();
 
 
-    virtual AttribDefs drawAttribs() const;
+    virtual bool intersects( const QgsRectangle &rect, const QgsMapSettings &settings, bool contains ) const;
 
-    virtual AttribValues drawAttribsFromPosition( const KadasMapPos &pos, const QgsMapSettings &mapSettings ) const;
-
-    virtual KadasMapPos positionFromDrawAttribs( const AttribValues &values, const QgsMapSettings &mapSettings ) const;
-
+    virtual QList<KadasMapItem::Node> nodes( const QgsMapSettings &settings ) const;
 
     virtual EditContext getEditContext( const KadasMapPos &pos, const QgsMapSettings &mapSettings ) const;
 
@@ -57,39 +64,62 @@ the Free Software Foundation; either version 2 of the License, or     *
     virtual void edit( const EditContext &context, const AttribValues &values, const QgsMapSettings &mapSettings );
 
 
+    virtual AttribDefs drawAttribs() const;
+
+    virtual AttribValues drawAttribsFromPosition( const KadasMapPos &pos, const QgsMapSettings &mapSettings ) const;
+
+    virtual KadasMapPos positionFromDrawAttribs( const AttribValues &values, const QgsMapSettings &mapSettings ) const;
+
+
     virtual AttribValues editAttribsFromPosition( const EditContext &context, const KadasMapPos &pos, const QgsMapSettings &mapSettings ) const;
 
     virtual KadasMapPos positionFromEditAttribs( const EditContext &context, const AttribValues &values, const QgsMapSettings &mapSettings ) const;
 
 
-    virtual KadasItemPos position() const;
-
-    virtual void setPosition( const KadasItemPos &pos );
-
-
-    virtual Qgis::GeometryType geometryType() const;
-    virtual void addPartFromGeometry( const QgsAbstractGeometry &geom );
+  protected:
+    virtual bool useQgisAnnotations() const;
+    virtual void updateQgsAnnotation() = 0;
 
 
-    const QgsMultiPoint *geometry() const;
+};
 
-    struct State : KadasMapItem::State
-    {
-        QList<KadasItemPos> points;
-        virtual void assign( const KadasMapItem::State *other );
-        virtual State *clone() const /Factory/;
-        virtual QJsonObject serialize() const;
 
-        virtual bool deserialize( const QJsonObject &json );
+class KadasPointItem : KadasAbstractPointItem
+{
 
-    };
-    const State *constState() const;
+%TypeHeaderCode
+#include "kadas/gui/mapitems/kadaspointitem.h"
+%End
+  public:
+    KadasPointItem( const QgsCoordinateReferenceSystem &crs, Qgis::MarkerShape icon = Qgis::MarkerShape::Circle );
+
+    virtual QgsAnnotationMarkerItem *annotationItem( const QgsCoordinateReferenceSystem &crs = QgsCoordinateReferenceSystem() ) const /Factory/;
+
+    virtual QString itemName() const;
+
+    virtual void setItemGeometry( const QgsPointXY &point );
+
+    virtual QgsRectangle boundingBox() const;
+
+    virtual void render( QgsRenderContext &context ) const;
+
+    void setShape( Qgis::MarkerShape shape );
+    Qgis::MarkerShape shape() const;
+    void setIconSize( int size );
+    int iconSize() const;
+    void setColor( const QColor &color );
+    QColor color() const;
+    void setStrokeColor( const QColor &strokeColor );
+    QColor strokeColor() const;
+    void setStrokeWidth( double width );
+    double strokeWidth() const;
+    void setStrokeStyle( const Qt::PenStyle &style );
+    Qt::PenStyle strokeStyle() const;
 
   protected:
-    virtual KadasMapItem *_clone() const /Factory/;
-    virtual State *createEmptyState() const /Factory/;
-    virtual void recomputeDerived();
-
+    virtual KadasMapItem *_clone() const;
+    virtual void writeXmlPrivate( QDomElement &element ) const;
+    virtual void readXmlPrivate( const QDomElement &element );
 
 };
 

--- a/python/kadasgui/auto_generated/mapitems/kadaspolygonitem.sip.in
+++ b/python/kadasgui/auto_generated/mapitems/kadaspolygonitem.sip.in
@@ -96,6 +96,7 @@ the Free Software Foundation; either version 2 of the License, or     *
 
   protected:
     virtual KadasMapItem *_clone() const /Factory/;
+
     virtual State *createEmptyState() const /Factory/;
     virtual void recomputeDerived();
 

--- a/python/kadasgui/auto_generated/mapitems/kadasrectangleitembase.sip.in
+++ b/python/kadasgui/auto_generated/mapitems/kadasrectangleitembase.sip.in
@@ -35,13 +35,13 @@ the Free Software Foundation; either version 2 of the License, or     *
     bool positionLocked() const;
     void setPositionLocked( bool locked );
 
-    virtual KadasItemRect boundingBox() const;
+    virtual QgsRectangle boundingBox() const;
 
     virtual Margin margin() const;
 
     virtual QList<KadasMapItem::Node> nodes( const QgsMapSettings &settings ) const;
 
-    virtual bool intersects( const KadasMapRect &rect, const QgsMapSettings &settings, bool contains = false ) const;
+    virtual bool intersects( const QgsRectangle &rect, const QgsMapSettings &settings, bool contains = false ) const;
 
     virtual void render( QgsRenderContext &context ) const;
 

--- a/python/kadasgui/auto_generated/mapitems/kadasselectionrectitem.sip.in
+++ b/python/kadasgui/auto_generated/mapitems/kadasselectionrectitem.sip.in
@@ -33,12 +33,12 @@ the Free Software Foundation; either version 2 of the License, or     *
 
     virtual QString itemName() const;
 
-    virtual KadasItemRect boundingBox() const;
+    virtual QgsRectangle boundingBox() const;
 
     virtual Margin margin() const;
 
     virtual QList<KadasMapItem::Node> nodes( const QgsMapSettings &settings ) const;
-    virtual bool intersects( const KadasMapRect &rect, const QgsMapSettings &settings, bool contains = false ) const;
+    virtual bool intersects( const QgsRectangle &rect, const QgsMapSettings &settings, bool contains = false ) const;
 
     virtual void render( QgsRenderContext &context ) const;
 

--- a/python/kadasgui/auto_generated/mapitems/kadastextitem.sip.in
+++ b/python/kadasgui/auto_generated/mapitems/kadastextitem.sip.in
@@ -10,7 +10,8 @@
 
 
 
-class KadasTextItem : KadasRectangleItemBase
+
+class KadasTextItem : KadasAbstractPointItem
 {
 %Docstring(signature="appended")
 *************************************************************************
@@ -31,26 +32,29 @@ the Free Software Foundation; either version 2 of the License, or     *
 
     virtual QString itemName() const;
 
+    virtual void setItemGeometry( const QgsPointXY &point );
+
+    virtual QgsAnnotationPointTextItem *annotationItem( const QgsCoordinateReferenceSystem &crs = QgsCoordinateReferenceSystem() ) const /Factory/;
+
     void setText( const QString &text );
     const QString &text() const;
-    void setFillColor( const QColor &c );
-    QColor fillColor() const;
-    void setOutlineColor( const QColor &c );
-    QColor outlineColor() const;
+
+    void setColor( const QColor &color );
+    QColor color() const;
+
     void setFont( const QFont &font );
     const QFont &font() const;
-    void setFrameAutoResize( bool frameAutoResize );
-    bool frameAutoResize() const;
-    void setAngle( double angle );
 
-    virtual QImage symbolImage() const;
+    virtual QgsRectangle boundingBox() const;
+    virtual void render( QgsRenderContext &context ) const;
+
 
 
 
   protected:
-    virtual void renderPrivate( QgsRenderContext &context, const QPointF &center, const QRect &rect, double dpiScale ) const;
-    virtual void editPrivate( const KadasMapPos &newPoint, const QgsMapSettings &mapSettings );
-    virtual void populateContextMenuPrivate( QMenu *menu, const EditContext &context, const KadasMapPos &clickPos, const QgsMapSettings &mapSettings );
+    virtual KadasMapItem *_clone() const;
+    virtual void writeXmlPrivate( QDomElement &element ) const;
+    virtual void readXmlPrivate( const QDomElement &element );
 
 };
 

--- a/python/kadasgui/auto_generated/maptools/kadasmaptoolcreateitem.sip.in
+++ b/python/kadasgui/auto_generated/maptools/kadasmaptoolcreateitem.sip.in
@@ -49,7 +49,6 @@ the Free Software Foundation; either version 2 of the License, or     *
 
 
     const KadasMapItem *currentItem() const;
-    KadasMapItem *takeItem();
     const KadasMapItemEditor *currentEditor() const;
 
     void setMultipart( bool multipart );

--- a/python/kadasgui/auto_generated/milx/kadasmilxitem.sip.in
+++ b/python/kadasgui/auto_generated/milx/kadasmilxitem.sip.in
@@ -37,7 +37,7 @@ class KadasMilxItem : KadasMapItem
 
     virtual QPointF symbolAnchor() const;
 
-    virtual KadasItemRect boundingBox() const;
+    virtual QgsRectangle boundingBox() const;
 
     virtual Margin margin() const;
 
@@ -45,7 +45,7 @@ class KadasMilxItem : KadasMapItem
     virtual QList<KadasMapItem::Node> nodes( const QgsMapSettings &settings ) const;
 
 
-    virtual bool intersects( const KadasMapRect &rect, const QgsMapSettings &settings, bool contains = false ) const;
+    virtual bool intersects( const QgsRectangle &rect, const QgsMapSettings &settings, bool contains = false ) const;
 
     virtual bool hitTest( const KadasMapPos &pos, const QgsMapSettings &settings ) const;
 

--- a/python/kadasgui/kadasgui_auto.sip
+++ b/python/kadasgui/kadasgui_auto.sip
@@ -12,6 +12,7 @@
 %Include auto_generated/maptools/kadasmaptoolheightprofile.sip
 %Include auto_generated/kadassearchprovider.sip
 %Include auto_generated/kadasmapiteminterface.sip
+%Include auto_generated/3d/kadasmapitemlayer3drenderer.sip
 %Include auto_generated/kadasitemcontextmenuactions.sip
 %Include auto_generated/kadasmapcanvasitemmanager.sip
 %Include auto_generated/kadascatalogbrowser.sip

--- a/vcpkg/ports/qgis/3d-export.patch
+++ b/vcpkg/ports/qgis/3d-export.patch
@@ -1,0 +1,62 @@
+From 0e10a84b958e12ba9f03bddb29fe479e1fcf3de1 Mon Sep 17 00:00:00 2001
+From: Denis Rouzaud <denis.rouzaud@gmail.com>
+Date: Fri, 28 Nov 2025 07:30:02 +0100
+Subject: [PATCH 1/2] Add _3D_EXPORT to annotation layer classes
+
+---
+ src/3d/qgsannotationlayerchunkloader_p.h | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/3d/qgsannotationlayerchunkloader_p.h b/src/3d/qgsannotationlayerchunkloader_p.h
+index 80406f4ae614..ac358ed7379e 100644
+--- a/src/3d/qgsannotationlayerchunkloader_p.h
++++ b/src/3d/qgsannotationlayerchunkloader_p.h
+@@ -53,7 +53,7 @@ namespace Qt3DCore
+  *
+  * \since QGIS 4.0
+  */
+-class QgsAnnotationLayerChunkLoaderFactory : public QgsQuadtreeChunkLoaderFactory
++class _3D_EXPORT QgsAnnotationLayerChunkLoaderFactory : public QgsQuadtreeChunkLoaderFactory
+ {
+     Q_OBJECT
+ 
+@@ -83,7 +83,7 @@ class QgsAnnotationLayerChunkLoaderFactory : public QgsQuadtreeChunkLoaderFactor
+  *
+  * \since QGIS 4.0
+  */
+-class QgsAnnotationLayerChunkLoader : public QgsChunkLoader
++class _3D_EXPORT QgsAnnotationLayerChunkLoader : public QgsChunkLoader
+ {
+     Q_OBJECT
+ 
+@@ -126,7 +126,7 @@ class QgsAnnotationLayerChunkLoader : public QgsChunkLoader
+  *
+  * \since QGIS 4.0
+  */
+-class QgsAnnotationLayerChunkedEntity : public QgsChunkedEntity
++class _3D_EXPORT QgsAnnotationLayerChunkedEntity : public QgsChunkedEntity
+ {
+     Q_OBJECT
+   public:
+
+From 78d849c21aaccf4bdc0b76637b50e6d565e1d33a Mon Sep 17 00:00:00 2001
+From: Denis Rouzaud <denis.rouzaud@gmail.com>
+Date: Fri, 28 Nov 2025 08:12:55 +0100
+Subject: [PATCH 2/2] Add include for qgis_3d.h in chunk loader header
+
+---
+ src/3d/qgsannotationlayerchunkloader_p.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/3d/qgsannotationlayerchunkloader_p.h b/src/3d/qgsannotationlayerchunkloader_p.h
+index ac358ed7379e..b2ed78c166e2 100644
+--- a/src/3d/qgsannotationlayerchunkloader_p.h
++++ b/src/3d/qgsannotationlayerchunkloader_p.h
+@@ -27,6 +27,7 @@
+ // version without notice, or even be removed.
+ //
+ 
++#include "qgis_3d.h"
+ #include "qgschunkloader.h"
+ #include "qgschunkedentity.h"
+ #include "qgs3drendercontext.h"

--- a/vcpkg/ports/qgis/3d-export.patch
+++ b/vcpkg/ports/qgis/3d-export.patch
@@ -1,55 +1,28 @@
-From 0e10a84b958e12ba9f03bddb29fe479e1fcf3de1 Mon Sep 17 00:00:00 2001
+From 0075118d55e1bcd61d61273b0a00b633615c4a92 Mon Sep 17 00:00:00 2001
 From: Denis Rouzaud <denis.rouzaud@gmail.com>
 Date: Fri, 28 Nov 2025 07:30:02 +0100
-Subject: [PATCH 1/2] Add _3D_EXPORT to annotation layer classes
+Subject: [PATCH] Add QGIS_3D_EXPORT to annotation layer classes
 
 ---
- src/3d/qgsannotationlayerchunkloader_p.h | 6 +++---
- 1 file changed, 3 insertions(+), 3 deletions(-)
+ src/3d/chunks/qgschunkedentity.h         | 2 +-
+ src/3d/qgsannotationlayerchunkloader_p.h | 7 ++++---
+ 2 files changed, 5 insertions(+), 4 deletions(-)
 
-diff --git a/src/3d/qgsannotationlayerchunkloader_p.h b/src/3d/qgsannotationlayerchunkloader_p.h
-index 80406f4ae614..ac358ed7379e 100644
---- a/src/3d/qgsannotationlayerchunkloader_p.h
-+++ b/src/3d/qgsannotationlayerchunkloader_p.h
-@@ -53,7 +53,7 @@ namespace Qt3DCore
-  *
-  * \since QGIS 4.0
+diff --git a/src/3d/chunks/qgschunkedentity.h b/src/3d/chunks/qgschunkedentity.h
+index 46c7f88ff03c..1f5fe6abbdef 100644
+--- a/src/3d/chunks/qgschunkedentity.h
++++ b/src/3d/chunks/qgschunkedentity.h
+@@ -57,7 +57,7 @@ class QgsRayCastContext;
+  * \brief Implementation of entity that handles chunks of data organized in quadtree with loading data when necessary
+  * based on data error and unloading of data when data are not necessary anymore
   */
--class QgsAnnotationLayerChunkLoaderFactory : public QgsQuadtreeChunkLoaderFactory
-+class _3D_EXPORT QgsAnnotationLayerChunkLoaderFactory : public QgsQuadtreeChunkLoaderFactory
- {
-     Q_OBJECT
- 
-@@ -83,7 +83,7 @@ class QgsAnnotationLayerChunkLoaderFactory : public QgsQuadtreeChunkLoaderFactor
-  *
-  * \since QGIS 4.0
-  */
--class QgsAnnotationLayerChunkLoader : public QgsChunkLoader
-+class _3D_EXPORT QgsAnnotationLayerChunkLoader : public QgsChunkLoader
- {
-     Q_OBJECT
- 
-@@ -126,7 +126,7 @@ class QgsAnnotationLayerChunkLoader : public QgsChunkLoader
-  *
-  * \since QGIS 4.0
-  */
--class QgsAnnotationLayerChunkedEntity : public QgsChunkedEntity
-+class _3D_EXPORT QgsAnnotationLayerChunkedEntity : public QgsChunkedEntity
+-class QgsChunkedEntity : public Qgs3DMapSceneEntity
++class _3D_EXPORT QgsChunkedEntity : public Qgs3DMapSceneEntity
  {
      Q_OBJECT
    public:
-
-From 78d849c21aaccf4bdc0b76637b50e6d565e1d33a Mon Sep 17 00:00:00 2001
-From: Denis Rouzaud <denis.rouzaud@gmail.com>
-Date: Fri, 28 Nov 2025 08:12:55 +0100
-Subject: [PATCH 2/2] Add include for qgis_3d.h in chunk loader header
-
----
- src/3d/qgsannotationlayerchunkloader_p.h | 1 +
- 1 file changed, 1 insertion(+)
-
 diff --git a/src/3d/qgsannotationlayerchunkloader_p.h b/src/3d/qgsannotationlayerchunkloader_p.h
-index ac358ed7379e..b2ed78c166e2 100644
+index 80406f4ae614..20976adf01c8 100644
 --- a/src/3d/qgsannotationlayerchunkloader_p.h
 +++ b/src/3d/qgsannotationlayerchunkloader_p.h
 @@ -27,6 +27,7 @@
@@ -60,3 +33,30 @@ index ac358ed7379e..b2ed78c166e2 100644
  #include "qgschunkloader.h"
  #include "qgschunkedentity.h"
  #include "qgs3drendercontext.h"
+@@ -53,7 +54,7 @@ namespace Qt3DCore
+  *
+  * \since QGIS 4.0
+  */
+-class QgsAnnotationLayerChunkLoaderFactory : public QgsQuadtreeChunkLoaderFactory
++class _3D_EXPORT QgsAnnotationLayerChunkLoaderFactory : public QgsQuadtreeChunkLoaderFactory
+ {
+     Q_OBJECT
+ 
+@@ -83,7 +84,7 @@ class QgsAnnotationLayerChunkLoaderFactory : public QgsQuadtreeChunkLoaderFactor
+  *
+  * \since QGIS 4.0
+  */
+-class QgsAnnotationLayerChunkLoader : public QgsChunkLoader
++class _3D_EXPORT QgsAnnotationLayerChunkLoader : public QgsChunkLoader
+ {
+     Q_OBJECT
+ 
+@@ -126,7 +127,7 @@ class QgsAnnotationLayerChunkLoader : public QgsChunkLoader
+  *
+  * \since QGIS 4.0
+  */
+-class QgsAnnotationLayerChunkedEntity : public QgsChunkedEntity
++class _3D_EXPORT QgsAnnotationLayerChunkedEntity : public QgsChunkedEntity
+ {
+     Q_OBJECT
+   public:

--- a/vcpkg/ports/qgis/portfile.cmake
+++ b/vcpkg/ports/qgis/portfile.cmake
@@ -32,6 +32,7 @@ vcpkg_from_github(
   flagDegreesUseUntranslatedStringSuffix.patch # https://jira.swisstopo.ch/browse/MGDIGRE_SB-1272
   wcsSpatialExtentSettings.patch # https://jira.swisstopo.ch/browse/MGDIGRE_SB-1201
   mac_install_images.patch
+  3d-export.patch
   reduceLayerPropertiesProviderSection.patch # https://github.com/qgis/QGIS/pull/64123
 )
 


### PR DESCRIPTION
supersedes #370, #390 and #400:

* moving away from using Q_PROPERTIES which are automagically read/written to XML using JSON (this is now manually written in read/write XML methods)
* adapt API to allow KadasMapItem to use QgsAnnotationItems for rendering (a virtual method of KadasMapItem states if it's using QGIS annotations or Kadas specific implementation)
* KadasPointItem and KadasTextItem now use QGIS annotations
* create a 3D renderer for Kadas Item layers that use a temporary QGIS annotation layer (by cloning KadasMapItem as QGIS annotations)

Points should be completly retro-compatible, while Texts come with some limitations for now:
* no frame allowed anymore (added in 2.3), could be re-added later on
* no outline color
* no callout (to be confirmed)