### PR TITLE
Alternative shortcut Ctrl+F12 for Network debug window

### DIFF
--- a/kadas/app/kadasmainwindow.cpp
+++ b/kadas/app/kadasmainwindow.cpp
@@ -407,6 +407,8 @@ void KadasMainWindow::init()
 
   QShortcut *networkLoggerShortcut = new QShortcut( QKeySequence( Qt::Key_F12 ), this );
   connect( networkLoggerShortcut, &QShortcut::activated, kApp, &KadasApplication::showNetworkLogger );
+  QShortcut *alternativeNetworkLoggerShortcut = new QShortcut( QKeySequence( Qt::CTRL + Qt::Key_F12 ), this );
+  connect( alternativeNetworkLoggerShortcut, &QShortcut::activated, kApp, &KadasApplication::showNetworkLogger );
 
   // Restore geometry
   restoreGeometry( QgsSettings().value( "/kadas/windowgeometry" ).toByteArray() );


### PR DESCRIPTION
Because when kadas is started from Visual Studio in debug mode, simple F12 is a shortcut to stop execution