### PR TITLE
Feature/portal sso http2

### DIFF
--- a/kadas/app/auth/kadasportalauth.cpp
+++ b/kadas/app/auth/kadasportalauth.cpp
@@ -120,10 +120,7 @@ void KadasPortalAuth::setupAuthentication()
             // Populate the cookie jar synchronously: the catalog browser starts
             // issuing requests as soon as the main window is constructed, and a
             // deferred singleShot would let those first requests go out without
-            // the agstoken cookie. The earlier delay was a workaround for being
-            // called from inside a QNAM reply slot, which no longer applies
-            // because blockingGet() above has already returned by the time we
-            // get here.
+            // the agstoken cookie.
             createCookies( token );
           }
           if ( settingsTokenUseEsriAuth->value() )

--- a/kadas/app/auth/kadasportalauth.cpp
+++ b/kadas/app/auth/kadasportalauth.cpp
@@ -19,11 +19,12 @@
 #include <QJsonObject>
 #include <QNetworkRequest>
 #include <QNetworkReply>
-#include <QTimer>
+#include <QUrlQuery>
 
 #include <qgis/qgsapplication.h>
 #include <qgis/qgsauthmanager.h>
 #include <qgis/qgsauthmethod.h>
+#include <qgis/qgsfeedback.h>
 #include <qgis/qgslogger.h>
 #include <qgis/qgsnetworkaccessmanager.h>
 #include <qgis/qgssettingsentryimpl.h>
@@ -92,11 +93,16 @@ void KadasPortalAuth::setupAuthentication()
   }
   else if ( !tokenUrl.isEmpty() )
   {
-    // Authentication via token
+    // Authentication via token. On Windows, Qt's QNetworkAccessManager handles
+    // Negotiate/NTLM transparently via SSPI when speaking HTTP/1.1 (HTTP/2 is
+    // globally disabled via KadasApplication::settingsDisableHttp2 to work
+    // around QTBUG-146829), so the logged-in Windows user's credentials are
+    // used silently without prompting.
     QgsDebugMsgLevel( QStringLiteral( "Extracting portal TOKEN from %1" ).arg( tokenUrl ), 1 );
 
     QNetworkRequest req = QNetworkRequest( QUrl( tokenUrl ) );
     QgsNetworkReplyContent content = QgsNetworkAccessManager::instance()->blockingGet( req );
+
     QString token;
     if ( content.error() == QNetworkReply::NoError )
     {

--- a/kadas/app/auth/kadasportalauth.cpp
+++ b/kadas/app/auth/kadasportalauth.cpp
@@ -111,10 +111,14 @@ void KadasPortalAuth::setupAuthentication()
           QgsDebugMsgLevel( QString( "ESRI Token found" ), 1 );
           if ( settingsTokenCreateCookies->value() )
           {
-            // If we create the cookies directly,
-            // it does not work in the same event loop
-            // so we need to delay it a bit
-            QTimer::singleShot( 1, this, [this, token]() { createCookies( token ); } );
+            // Populate the cookie jar synchronously: the catalog browser starts
+            // issuing requests as soon as the main window is constructed, and a
+            // deferred singleShot would let those first requests go out without
+            // the agstoken cookie. The earlier delay was a workaround for being
+            // called from inside a QNAM reply slot, which no longer applies
+            // because blockingGet() above has already returned by the time we
+            // get here.
+            createCookies( token );
           }
           if ( settingsTokenUseEsriAuth->value() )
             createEsriAuth( token );

--- a/kadas/app/kadasapplication.cpp
+++ b/kadas/app/kadasapplication.cpp
@@ -1727,6 +1727,7 @@ void KadasApplication::preprocessNetworkRequest( QNetworkRequest *request )
   // authenticationRequired retry loop never fires and the reply never emits
   // finished. Forcing HTTP/1.1 restores the Qt 5 behaviour (transparent
   // SSPI/SSO on Windows). Drop this once QTBUG-146829 is fixed in our Qt build.
+  // https://qt-project.atlassian.net/browse/QTBUG-146829
   if ( settingsDisableHttp2->value() )
   {
     request->setAttribute( QNetworkRequest::Http2AllowedAttribute, false );

--- a/kadas/app/kadasapplication.cpp
+++ b/kadas/app/kadasapplication.cpp
@@ -56,6 +56,8 @@
 #include <qgis/qgsproviderutils.h>
 #include <qgis/qgsrasterlayer.h>
 #include <qgis/qgsrasterlayerproperties.h>
+#include <qgis/qgssettingsentryimpl.h>
+#include <qgis/qgssettingstreenode.h>
 #include <qgis/qgssublayersdialog.h>
 #include <qgis/qgstaskmanager.h>
 #include <qgis/qgsvectorlayer.h>
@@ -69,6 +71,7 @@
 #include "kadas/app/devtools/kadasdevelopertoolsdockwidget.h"
 #include "kadas/app/auth/kadasportalauth.h"
 #include "kadas/core/kadas.h"
+#include "kadas/core/kadassettingstree.h"
 #include "kadas/gui/kadasattributetabledialog.h"
 #include "kadas/gui/kadasclipboard.h"
 #include "kadas/gui/kadasitemlayer.h"
@@ -156,6 +159,20 @@ static void setupVectorLayer( const QString &vectorLayerPath, const QStringList 
     }
   }
 }
+
+
+const QgsSettingsEntryBool *KadasApplication::settingsDisableHttp2 = new QgsSettingsEntryBool(
+  QStringLiteral( "disable-http2" ),
+  KadasSettingsTree::sTreeKadas,
+  true,
+  QStringLiteral(
+    "Force HTTP/1.1 on all outgoing requests (workaround for QTBUG-146829: QNAM does not fall back from HTTP/2 to HTTP/1.1 to perform the Negotiate/NTLM handshake, so requests to IWA-protected "
+    "endpoints hang). Drop the default once that bug is fixed in our Qt build."
+  )
+);
+
+const QgsSettingsEntryBool *KadasApplication::settingsInjectAuthToken
+  = new QgsSettingsEntryBool( QStringLiteral( "inject-auth-token" ), KadasSettingsTree::sTreeKadas, false, QStringLiteral( "Inject the ESRI portal token (extracted from the agstoken cookie) into outgoing requests." ) );
 
 
 KadasApplication *KadasApplication::instance()
@@ -313,11 +330,10 @@ void KadasApplication::init()
 
   Kadas::importSslCertificates();
 
-  // Add token injector
-  QgsNetworkAccessManager::setRequestPreprocessor( injectAuthToken );
-
-  // Add network request logger
-  QgsNetworkAccessManager::instance()->setRequestPreprocessor( []( QNetworkRequest *req ) { QgsDebugMsgLevel( QString( "Network request: %1" ).arg( req->url().toString() ), 2 ); } );
+  QgsNetworkAccessManager::setRequestPreprocessor( []( QNetworkRequest *req ) {
+    QgsDebugMsgLevel( QString( "Network request: %1" ).arg( req->url().toString() ), 2 );
+    preprocessNetworkRequest( req );
+  } );
 
   // Start the network logger early, we want all requests logged!
   mNetworkLogger = new QgsNetworkLogger( QgsNetworkAccessManager::instance(), this );
@@ -1684,6 +1700,11 @@ void KadasApplication::showNetworkLogger()
   }
 }
 
+void KadasApplication::setNetworkLoggingEnabled( bool enabled )
+{
+  mNetworkLogger->enableLogging( enabled );
+}
+
 QgsMessageOutput *KadasApplication::messageOutputViewer()
 {
   if ( QThread::currentThread() == kApp->thread() )
@@ -1697,9 +1718,21 @@ QgsMessageOutput *KadasApplication::messageOutputViewer()
 }
 
 
-void KadasApplication::injectAuthToken( QNetworkRequest *request )
+void KadasApplication::preprocessNetworkRequest( QNetworkRequest *request )
 {
-  if ( QgsSettings().value( "/kadas/injectAuthToken", false ).toBool() == false )
+  // HTTP/2 workaround for QTBUG-146829 ("QNAM must fall back to HTTP/1 (from
+  // HTTP/2) to perform NTLM handshake", split off from QTBUG-143926): QNAM
+  // hangs on IWA/Negotiate-protected endpoints when the server negotiates
+  // HTTP/2 via ALPN — the 401 challenge is received but the
+  // authenticationRequired retry loop never fires and the reply never emits
+  // finished. Forcing HTTP/1.1 restores the Qt 5 behaviour (transparent
+  // SSPI/SSO on Windows). Drop this once QTBUG-146829 is fixed in our Qt build.
+  if ( settingsDisableHttp2->value() )
+  {
+    request->setAttribute( QNetworkRequest::Http2AllowedAttribute, false );
+  }
+
+  if ( !settingsInjectAuthToken->value() )
   {
     return;
   }
@@ -1711,12 +1744,12 @@ void KadasApplication::injectAuthToken( QNetworkRequest *request )
   {
     return;
   }
-  QgsDebugMsgLevel( QString( "injectAuthToken: got url %1" ).arg( url.url() ), 2 );
+  QgsDebugMsgLevel( QString( "preprocessNetworkRequest: got url %1" ).arg( url.url() ), 2 );
   // Extract the token from the esri_auth cookie, if such cookie exists in the pool
   QList<QNetworkCookie> cookies = nam->cookieJar()->cookiesForUrl( request->url() );
   for ( const QNetworkCookie &cookie : cookies )
   {
-    QgsDebugMsgLevel( QString( "injectAuthToken: got cookie %1 for url %2" ).arg( QString::fromUtf8( cookie.toRawForm() ) ).arg( url.url() ), 2 );
+    QgsDebugMsgLevel( QString( "preprocessNetworkRequest: got cookie %1 for url %2" ).arg( QString::fromUtf8( cookie.toRawForm() ) ).arg( url.url() ), 2 );
     QByteArray data = QUrl::fromPercentEncoding( cookie.toRawForm() ).toLocal8Bit();
     if ( data.startsWith( "agstoken=" ) )
     {
@@ -1727,7 +1760,7 @@ void KadasApplication::injectAuthToken( QNetworkRequest *request )
         query.addQueryItem( "token", tokenMatch.captured( 1 ) );
         url.setQuery( query );
         request->setUrl( url );
-        QgsDebugMsgLevel( QString( "injectAuthToken: url altered to %1" ).arg( url.toString() ), 2 );
+        QgsDebugMsgLevel( QString( "preprocessNetworkRequest: url altered to %1" ).arg( url.toString() ), 2 );
         break;
       }
     }

--- a/kadas/app/kadasapplication.h
+++ b/kadas/app/kadasapplication.h
@@ -36,6 +36,7 @@ class QgsMapLayerConfigWidgetFactory;
 class QgsMapTool;
 class QgsMessageOutput;
 class QgsNetworkLogger;
+class QgsSettingsEntryBool;
 class QgsPointCloudLayer;
 class QgsPrintLayout;
 class QgsRasterLayer;
@@ -121,6 +122,7 @@ class KadasApplication : public QgsApplication
     void displayMessage( const QString &message, Qgis::MessageLevel level = Qgis::Info );
     void showPythonConsole();
     void showNetworkLogger();
+    void setNetworkLoggingEnabled( bool enabled );
     void unsetMapTool();
 
     void initAfterExec();
@@ -165,7 +167,14 @@ class KadasApplication : public QgsApplication
     void mergeChildSettingsGroups( QgsSettings &settings, QgsSettings &newSettings );
 
     static QgsMessageOutput *messageOutputViewer();
-    static void injectAuthToken( QNetworkRequest *request );
+
+    //! Applies app-wide tweaks to outgoing network requests (HTTP/2 disable, ESRI token injection, ...).
+    static void preprocessNetworkRequest( QNetworkRequest *request );
+
+    //! When true, force HTTP/1.1 on all outgoing requests (workaround for QTBUG-143926).
+    static const QgsSettingsEntryBool *settingsDisableHttp2;
+    //! When true, inject the ESRI portal token (extracted from the agstoken cookie) into outgoing requests.
+    static const QgsSettingsEntryBool *settingsInjectAuthToken;
 
 
   private slots:


### PR DESCRIPTION
## HTTP/2 + IWA portal SSO regression on Qt 6 — summary

### Symptom
On Windows, fetching the ESRI portal token (or any other endpoint protected by Integrated Windows Authentication / Negotiate / NTLM) hangs indefinitely under Qt 6 when the server advertises HTTP/2 via ALPN. Under Qt 5 the same flow worked silently via SSPI.

### Root cause
`QNetworkAccessManager` does receive the `401 WWW-Authenticate: Negotiate` challenge, but over an HTTP/2 connection it:
1. Never falls back to HTTP/1.1 to perform the multi-round NTLM/Negotiate handshake (which is fundamentally a connection-oriented HTTP/1 mechanism).
2. Never emits `authenticationRequired` and never emits `finished` on the reply, so the caller hangs.

### Qt tickets
- [QTBUG-146829](https://bugreports.qt.io/browse/QTBUG-146829) — **"QNAM must fall back to HTTP/1 (from HTTP/2) to perform NTLM handshake"**. Reported, P2, assigned to Mårten Nordheim. **This is the ticket whose fix lets us drop the workaround.**
- [QTBUG-143926](https://bugreports.qt.io/browse/QTBUG-143926) — originally covered the whole problem, since narrowed (reworded) to only the "QNAM/QNetworkReply must emit `finished` even when the connection fails" symptom. P2, affects 6.8.6 & 6.10.2. If only this ships, the app would fail-fast instead of hanging — still broken for SSO.

### Workaround
Force HTTP/1.1 on every outgoing QNAM request via a request preprocessor, gated by a new setting: 
`kadas/disable-http2` sets `QNetworkRequest::Http2AllowedAttribute = false` in `KadasApplication::preprocessNetworkRequest`. HTTP/1.1 lets Qt's SSPI integration negotiate transparently, restoring the Qt 5 behaviour.

### Why disable HTTP/2 for *every* request and not only the token fetch?
The token endpoint is just the one URL where the hang is guaranteed. Once signed in, the app keeps talking to the same ArcGIS Server / portal (and to any other IWA-protected service the customer points Kadas at) for map services, feature services, WFS, print, etc. Whether any individual call needs a fresh Negotiate handshake depends on the route, on `agstoken` cookie acceptance, on session/cookie expiry, and on what other internal endpoints are configured — none of which we can reliably predict.

Per-request gating would mean maintaining a per-deployment allowlist of "hosts that may challenge with Negotiate", which would be wrong by default. The downside of being too wide is small (HTTP/1.1 vs HTTP/2 to a LAN portal is a perf footnote); the downside of being too narrow is a hung app. `kadas/disable-http2` is the escape hatch if a deployment ever needs to flip it off.

### Removal criteria
Drop `kadas/disable-http2`'s `true` default (and ideally the setting + preprocessor line) once **QTBUG-146829** is fixed in the Qt version we ship.
