### PR TITLE
Force light theme regardless of OS preference

### DIFF
--- a/kadas/app/kadasapplication.cpp
+++ b/kadas/app/kadasapplication.cpp
@@ -25,6 +25,7 @@
 #include <QMessageBox>
 #include <QSplashScreen>
 #include <QStatusBar>
+#include <QStyleHints>
 #include <QRegularExpression>
 #include <QUrlQuery>
 #include <quazip/quazipfile.h>
@@ -284,6 +285,7 @@ void KadasApplication::init()
   if ( styleSheet.open( QIODevice::ReadOnly ) )
   {
     setStyleSheet( QString::fromLocal8Bit( styleSheet.readAll() ) );
+    styleHints()->setColorScheme( Qt::ColorScheme::Light ); // Force kadas to use light theme regardless of OS system theme
   }
 
   // Create / migrate settings


### PR DESCRIPTION
The kadas 3 had UI glitches when using with dark mode preference from the OS. 

This solves the issues by fallback to light theme regardless of the OS preference like it was in Kadas 2.3

<img width="1022" height="893" alt="image" src="https://github.com/user-attachments/assets/bbfe4c0d-6e01-4fc8-b605-454a056dfd0e" />
