### PR TITLE
Fix crash when searching for location in Kadas

### DIFF
--- a/kadas/gui/search/kadaslocationsearchprovider.cpp
+++ b/kadas/gui/search/kadaslocationsearchprovider.cpp
@@ -85,19 +85,7 @@ KadasLocationSearchFilter::KadasLocationSearchFilter( QgsMapCanvas *mapCanvas )
   mCategoryMap.insert( "gazetteer", qMakePair( tr( "General place name directory" ), 21 ) );
 }
 
-KadasLocationSearchFilter::~KadasLocationSearchFilter()
-{
-  if ( mCurrentReply )
-  {
-    mCurrentReply->abort();
-    mCurrentReply->deleteLater();
-  }
-  if ( mEventLoop )
-  {
-    mEventLoop->quit();
-    delete mEventLoop;
-  }
-}
+KadasLocationSearchFilter::~KadasLocationSearchFilter() = default;
 
 QgsLocatorFilter *KadasLocationSearchFilter::clone() const
 {
@@ -108,15 +96,6 @@ void KadasLocationSearchFilter::fetchResults( const QString &string, const QgsLo
 {
   if ( string.length() < 3 )
     return;
-
-  if ( mCurrentReply )
-  {
-    mCurrentReply->abort();
-    mCurrentReply->deleteLater();
-    mCurrentReply = nullptr;
-  }
-
-  mFeedback = feedback;
 
   QString serviceUrl;
   if ( QgsSettings().value( "/kadas/isOffline" ).toBool() )
@@ -147,48 +126,37 @@ void KadasLocationSearchFilter::fetchResults( const QString &string, const QgsLo
   QNetworkRequest req( url );
   req.setRawHeader( "Referer", QgsSettings().value( "search/referer", "http://localhost" ).toByteArray() );
 
-  //QgsNetworkAccessManager *nam = QgsNetworkAccessManager::instance();
-  // we have performance issues with QgsNetworkAccessManager::instance()
-  QNetworkAccessManager *nam = new QNetworkAccessManager( this );
-  mCurrentReply = nam->get( req );
+  // Perform the request synchronously on this locator worker thread with QgsBlockingNetworkRequest
+  QgsBlockingNetworkRequest blockingRequest;
+  const QgsBlockingNetworkRequest::ErrorCode errorCode = blockingRequest.get( req, false, feedback );
 
-  mEventLoop = new QEventLoop;
-  connect( mCurrentReply, &QNetworkReply::finished, this, &KadasLocationSearchFilter::handleNetworkReply );
-  connect( feedback, &QgsFeedback::canceled, mEventLoop, [&]() {
-    mCurrentReply->abort();
-    mCurrentReply->deleteLater();
-    mCurrentReply = nullptr;
-    mEventLoop->quit();
-  } );
+  if ( feedback && feedback->isCanceled() )
+    return;
+  if ( errorCode != QgsBlockingNetworkRequest::NoError )
+  {
+    QgsDebugMsgLevel( QString( "Location search request failed: %1" ).arg( blockingRequest.errorMessage() ), 2 );
+    return;
+  }
 
-  mEventLoop->exec();
-  delete mEventLoop;
-  mEventLoop = nullptr;
+  parseReply( blockingRequest.reply().content(), feedback );
 }
 
-void KadasLocationSearchFilter::handleNetworkReply()
+void KadasLocationSearchFilter::parseReply( const QByteArray &replyContent, QgsFeedback *feedback )
 {
-  if ( !mCurrentReply )
-    return;
-
-  QByteArray replyContent = mCurrentReply->readAll();
   QJsonParseError err;
   QJsonDocument doc = QJsonDocument::fromJson( replyContent, &err );
   if ( doc.isNull() )
+  {
     QgsDebugMsgLevel( QString( "Parsing error: %1" ).arg( err.errorString() ), 2 );
+    return;
+  }
 
   QJsonObject resultMap = doc.object();
   const QJsonArray constResults = resultMap["results"].toArray();
   for ( const QJsonValue &item : constResults )
   {
-    if ( mFeedback && mFeedback->isCanceled() )
-    {
-      mCurrentReply->deleteLater();
-      mCurrentReply = nullptr;
-      if ( mEventLoop )
-        mEventLoop->quit();
+    if ( feedback && feedback->isCanceled() )
       return;
-    }
 
     QJsonObject itemMap = item.toObject();
     QJsonObject itemAttrsMap = itemMap["attrs"].toObject();
@@ -229,10 +197,6 @@ void KadasLocationSearchFilter::handleNetworkReply()
     result.setUserData( resultData );
     emit resultFetched( result );
   }
-  mCurrentReply->deleteLater();
-  mCurrentReply = nullptr;
-  if ( mEventLoop )
-    mEventLoop->quit();
 }
 
 void KadasLocationSearchFilter::triggerResult( const QgsLocatorResult &result )

--- a/kadas/gui/search/kadaslocationsearchprovider.h
+++ b/kadas/gui/search/kadaslocationsearchprovider.h
@@ -25,9 +25,6 @@
 
 #include "kadas/gui/kadas_gui.h"
 
-class QNetworkReply;
-class QEventLoop;
-
 class QgsMapCanvas;
 class QgsFillSymbol;
 
@@ -58,12 +55,7 @@ class KADAS_GUI_EXPORT KadasLocationSearchFilter : public QgsLocatorFilter
     QString mPinItemId;
     QStringList mGeometryItemIds;
 
-    QEventLoop *mEventLoop = nullptr;
-    QNetworkReply *mCurrentReply = nullptr;
-    QgsFeedback *mFeedback = nullptr;
-
-  private slots:
-    void handleNetworkReply();
+    void parseReply( const QByteArray &replyContent, QgsFeedback *feedback );
 };
 
 #endif // KADASLOCATIONSEARCHPROVIDER_H

--- a/kadas/gui/search/kadasworldlocationsearchprovider.cpp
+++ b/kadas/gui/search/kadasworldlocationsearchprovider.cpp
@@ -37,6 +37,7 @@
 #include <qgis/qgslinesymbol.h>
 #include <qgis/qgslinesymbollayer.h>
 #include <qgis/qgslogger.h>
+#include <qgis/qgsblockingnetworkrequest.h>
 #include <qgis/qgsmapcanvas.h>
 #include <qgis/qgsmarkersymbol.h>
 #include <qgis/qgsmarkersymbollayer.h>
@@ -68,8 +69,6 @@ void KadasWorldLocationSearchProvider::fetchResults( const QString &string, cons
   if ( string.length() < 3 )
     return;
 
-  mFeedback = feedback;
-
   QString serviceUrl;
   if ( QgsSettings().value( "/kadas/isOffline" ).toBool() )
   {
@@ -100,52 +99,36 @@ void KadasWorldLocationSearchProvider::fetchResults( const QString &string, cons
   QNetworkRequest req( url );
   req.setRawHeader( "Referer", QgsSettings().value( "search/referer", "http://localhost" ).toByteArray() );
 
-  //QgsNetworkAccessManager *nam = QgsNetworkAccessManager::instance();
-  // we have performance issues with QgsNetworkAccessManager::instance()
-  QNetworkAccessManager *nam = new QNetworkAccessManager( this );
-  mCurrentReply = nam->get( req );
+  // same pattern as kadaslocationsearchprovider.cpp
+  QgsBlockingNetworkRequest blockingRequest;
+  const QgsBlockingNetworkRequest::ErrorCode errorCode = blockingRequest.get( req, false, feedback );
 
-  mEventLoop = new QEventLoop;
-  connect( mCurrentReply, &QNetworkReply::finished, this, &KadasWorldLocationSearchProvider::handleNetworkReply );
-  connect( feedback, &QgsFeedback::canceled, mEventLoop, [&]() {
-    if ( mCurrentReply )
-    {
-      mCurrentReply->abort();
-      mCurrentReply->deleteLater();
-      mCurrentReply = nullptr;
-    }
-    if ( mEventLoop )
-      mEventLoop->quit();
-  } );
-  mEventLoop->exec();
-  delete mEventLoop;
-  mEventLoop = nullptr;
+  if ( feedback && feedback->isCanceled() )
+    return;
+  if ( errorCode != QgsBlockingNetworkRequest::NoError )
+  {
+    QgsDebugMsgLevel( QString( "World location search request failed: %1" ).arg( blockingRequest.errorMessage() ), 2 );
+    return;
+  }
+
+  parseReply( blockingRequest.reply().content(), feedback );
 }
 
-void KadasWorldLocationSearchProvider::handleNetworkReply()
+void KadasWorldLocationSearchProvider::parseReply( const QByteArray &replyContent, QgsFeedback *feedback )
 {
-  if ( !mCurrentReply )
-    return;
-
-  QByteArray replyText = mCurrentReply->readAll();
   QJsonParseError err;
-  QJsonDocument doc = QJsonDocument::fromJson( replyText, &err );
+  QJsonDocument doc = QJsonDocument::fromJson( replyContent, &err );
   if ( doc.isNull() )
   {
     QgsDebugMsgLevel( QString( "Parsing error: %1" ).arg( err.errorString() ), 2 );
+    return;
   }
   QJsonObject resultMap = doc.object();
   const QJsonArray constResults = resultMap["results"].toArray();
   for ( const QJsonValue &item : constResults )
   {
-    if ( mFeedback && mFeedback->isCanceled() )
-    {
-      mCurrentReply->deleteLater();
-      mCurrentReply = nullptr;
-      if ( mEventLoop )
-        mEventLoop->quit();
+    if ( feedback && feedback->isCanceled() )
       return;
-    }
     QJsonObject itemMap = item.toObject();
     QJsonObject itemAttrsMap = itemMap["attrs"].toObject();
     QString origin = itemAttrsMap["origin"].toString();
@@ -173,10 +156,6 @@ void KadasWorldLocationSearchProvider::handleNetworkReply()
     result.setUserData( resultData );
     emit resultFetched( result );
   }
-  mCurrentReply->deleteLater();
-  mCurrentReply = nullptr;
-  if ( mEventLoop )
-    mEventLoop->quit();
 }
 
 void KadasWorldLocationSearchProvider::triggerResult( const QgsLocatorResult &result )

--- a/kadas/gui/search/kadasworldlocationsearchprovider.h
+++ b/kadas/gui/search/kadasworldlocationsearchprovider.h
@@ -24,9 +24,6 @@
 #include "kadas/gui/kadas_gui.h"
 
 
-class QNetworkReply;
-class QEventLoop;
-
 class QgsMapCanvas;
 
 class KADAS_GUI_EXPORT KadasWorldLocationSearchProvider : public QgsLocatorFilter
@@ -43,9 +40,6 @@ class KADAS_GUI_EXPORT KadasWorldLocationSearchProvider : public QgsLocatorFilte
     virtual void triggerResult( const QgsLocatorResult &result ) override;
     virtual void clearPreviousResults() override;
 
-  private slots:
-    void handleNetworkReply();
-
   private:
     static const int sResultCountLimit;
 
@@ -54,9 +48,7 @@ class KADAS_GUI_EXPORT KadasWorldLocationSearchProvider : public QgsLocatorFilte
     QgsMapCanvas *mMapCanvas = nullptr;
     QMap<QString, QPair<QString, int>> mCategoryMap;
 
-    QNetworkReply *mCurrentReply = nullptr;
-    QgsFeedback *mFeedback = nullptr;
-    QEventLoop *mEventLoop = nullptr;
+    void parseReply( const QByteArray &replyContent, QgsFeedback *feedback );
 };
 
 #endif // KADASWORLDVBSLOCATIONSEARCHPROVIDER_H


### PR DESCRIPTION
**Symptom**: on my linux build of Kadas, I noticed that the application crashed when searching for a location whenever I typed the location name more quickly.

**Problem**: When a user types in a name fast (a bunch of rapid keystrokes), then while a previous keystroke is still completing, a new keystroke triggers cancellation of previous search which causes main UI thread and background worker to try to double free the mCurrentReply pointer. 

**Solution**: Refactor location search providers to use QgsBlockingNetworkRequest to eliminate shared state with mCurrentReply.

**Testing**: Because I thought this might have just been a problem with my linux build, I tested the latest msi from the Windows build and the same crash occurred. The fix has been tested on linux but not windows