### PR TITLE
Fixing bookmark undefined behavior bug

### DIFF
--- a/kadas/app/kadasbookmarksmenu.cpp
+++ b/kadas/app/kadasbookmarksmenu.cpp
@@ -86,8 +86,10 @@ void KadasBookmarksMenu::addBookmarkAction( Bookmark *bookmark )
   // insert alphabetically
   const QList<QAction *> constMenuActions = actions();
   QAction *before = nullptr;
-  for ( QAction *action : constMenuActions ) {
-    if ( action->property( "name" ).toString().compare( bookmark->name, Qt::CaseSensitivity::CaseInsensitive ) > 0 ) {
+  for ( QAction *action : constMenuActions )
+  {
+    if ( action->property( "name" ).toString().compare( bookmark->name, Qt::CaseSensitivity::CaseInsensitive ) > 0 )
+    {
       before = action;
       break;
     }

--- a/kadas/app/kadasbookmarksmenu.cpp
+++ b/kadas/app/kadasbookmarksmenu.cpp
@@ -85,15 +85,14 @@ void KadasBookmarksMenu::addBookmarkAction( Bookmark *bookmark )
 
   // insert alphabetically
   const QList<QAction *> constMenuActions = actions();
-  QList<QAction *>::const_iterator it = constMenuActions.constBegin();
   QAction *before = nullptr;
-  for ( ; it != constMenuActions.constEnd(); it++ )
-  {
-    if ( bookmark->name.compare( ( *it )->property( "name" ).toString(), Qt::CaseSensitivity::CaseInsensitive ) > 0 )
-    {
-      before = *std::next( it );
+  for ( QAction *action : constMenuActions ) {
+    if ( action->property( "name" ).toString().compare( bookmark->name, Qt::CaseSensitivity::CaseInsensitive ) > 0 ) {
+      before = action;
+      break;
     }
   }
+
   if ( before )
     insertAction( before, widgetAction );
   else


### PR DESCRIPTION
Under an ASAN build, adding a bookmark crashes because adding a bookmark at the end of the sequence alphebetically tries to access after the end of the `constMenuActions`. This is a small fix for it.

Usually, this function works after a normal build but this is probably because it just points to bits in memory after, so it doesn't try to dereference a null pointer.

Error log for ASAN build:
```
SUMMARY: AddressSanitizer: heap-buffer-overflow /home/aloha/OPENGIS/kadas-albireo2/kadas/app/kadasbookmarksmenu.cpp:94 in KadasBookmarksMenu::addBookmarkAction(KadasBookmarksMenu::Bookmark*)
Shadow bytes around the buggy address:
  0x0a06801132e0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0a06801132f0: fa fa 00 00 00 fa fa fa 00 00 00 00 fa fa fa fa
  0x0a0680113300: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0a0680113310: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0a0680113320: fa fa fa fa fa fa fa fa fa fa fa fa fa fa 00 00
=>0x0a0680113330: 00 00 fa fa 00 00 00 00 fa fa 00 00 00 00[fa]fa
  0x0a0680113340: 00 00 00 00 fa fa 00 00 00 00 fa fa 00 00 00 00
  0x0a0680113350: fa fa 00 00 00 00 fa fa 00 00 00 00 fa fa 00 00
  0x0a0680113360: 04 fa fa fa 00 00 00 00 fa fa 00 00 00 00 fa fa
  0x0a0680113370: 00 00 00 00 fa fa 00 00 00 00 fa fa 00 00 00 fa
  0x0a0680113380: fa fa 00 00 04 fa fa fa 00 00 00 00 fa fa 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==201062==ABORTING
[1] + Done                       "/usr/bin/gdb" --interpreter=mi --tty=${DbgTerm} 0<"/tmp/Microsoft-MIEngine-In-1gogc2pz.3m5" 1>"/tmp/Microsoft-MIEngine-Out-cruaw0ak.zkp"

Press any key to continue...
```