### PR TITLE
Adding shortcut to filter layer properties with right click in Kadas

### DIFF
--- a/kadas/app/kadasapplication.cpp
+++ b/kadas/app/kadasapplication.cpp
@@ -66,8 +66,9 @@
 #include <qgis/qgssettingsentryimpl.h>
 #include <qgis/qgssettingstreenode.h>
 #include <qgis/qgssublayersdialog.h>
+#include <memory>
 #include <qgis/qgssubsetstringeditorinterface.h>
-#include <qgis/qgssubsetstringeditorproviderregistry.h>
+#include <qgis/qgssubsetstringeditorproviderregistry.h
 #include <qgis/qgstaskmanager.h>
 #include <qgis/qgsvectorlayer.h>
 #include <qgis/qgsvectortilelayer.h>

--- a/kadas/app/kadasapplication.cpp
+++ b/kadas/app/kadasapplication.cpp
@@ -1080,12 +1080,13 @@ void KadasApplication::showLayerFilter( QgsMapLayer *layer )
     return;
 
   // opens specific dialog for filtering layer if available, otherwise shows generic query builder
-  std::unique_ptr<QgsSubsetStringEditorInterface> dialog( QgsGui::subsetStringEditorProviderRegistry()->createDialog( vlayer, mMainWindow ) );
+  QgsSubsetStringEditorInterface *dialog = QgsGui::subsetStringEditorProviderRegistry()->createDialog( vlayer, mMainWindow );
   if ( !dialog )
     return;
 
   dialog->setSubsetString( vlayer->subsetString() );
   dialog->exec();
+  delete dialog;
 }
 
 void KadasApplication::showLayerProperties( QgsMapLayer *layer )

--- a/kadas/app/kadasapplication.cpp
+++ b/kadas/app/kadasapplication.cpp
@@ -68,7 +68,7 @@
 #include <qgis/qgssublayersdialog.h>
 #include <memory>
 #include <qgis/qgssubsetstringeditorinterface.h>
-#include <qgis/qgssubsetstringeditorproviderregistry.h
+#include <qgis/qgssubsetstringeditorproviderregistry.h>
 #include <qgis/qgstaskmanager.h>
 #include <qgis/qgsvectorlayer.h>
 #include <qgis/qgsvectortilelayer.h>

--- a/kadas/app/kadasapplication.cpp
+++ b/kadas/app/kadasapplication.cpp
@@ -40,6 +40,7 @@
 #include <qgis/qgsdataitem.h>
 #include <qgis/qgsdatumtransformdialog.h>
 #include <qgis/qgsgdalutils.h>
+#include <qgis/qgsgui.h>
 #include <qgis/qgsguiutils.h>
 #include <qgis/qgslayertree.h>
 #include <qgis/qgslayertreemapcanvasbridge.h>
@@ -65,6 +66,8 @@
 #include <qgis/qgssettingsentryimpl.h>
 #include <qgis/qgssettingstreenode.h>
 #include <qgis/qgssublayersdialog.h>
+#include <qgis/qgssubsetstringeditorinterface.h>
+#include <qgis/qgssubsetstringeditorproviderregistry.h>
 #include <qgis/qgstaskmanager.h>
 #include <qgis/qgsvectorlayer.h>
 #include <qgis/qgsvectortilelayer.h>
@@ -1068,6 +1071,21 @@ void KadasApplication::showLayerAttributeTable( QgsMapLayer *layer )
       = new KadasAttributeTableDialog( vlayer, mMainWindow->mapCanvas(), mMainWindow->messageBar(), mMainWindow, KadasAttributeTableDialog::settingsAttributeTableLocation->value() );
     table->show();
   }
+}
+
+void KadasApplication::showLayerFilter( QgsMapLayer *layer )
+{
+  QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( layer );
+  if ( !vlayer )
+    return;
+
+  // opens specific dialog for filtering layer if available, otherwise shows generic query builder
+  std::unique_ptr<QgsSubsetStringEditorInterface> dialog( QgsGui::subsetStringEditorProviderRegistry()->createDialog( vlayer, mMainWindow ) );
+  if ( !dialog )
+    return;
+
+  dialog->setSubsetString( vlayer->subsetString() );
+  dialog->exec();
 }
 
 void KadasApplication::showLayerProperties( QgsMapLayer *layer )

--- a/kadas/app/kadasapplication.h
+++ b/kadas/app/kadasapplication.h
@@ -101,6 +101,7 @@ class KadasApplication : public QgsApplication
     void saveMapToClipboard();
 
     void showLayerAttributeTable( QgsMapLayer *layer );
+    void showLayerFilter( QgsMapLayer *layer );
     void showLayerProperties( QgsMapLayer *layer );
     void showLayerInfo( const QgsMapLayer *layer );
     void showMessageLog();

--- a/kadas/app/layertree/kadaslayertreeviewmenuprovider.cpp
+++ b/kadas/app/layertree/kadaslayertreeviewmenuprovider.cpp
@@ -127,6 +127,7 @@ QMenu *KadasLayerTreeViewMenuProvider::createContextMenu()
       else if ( layer->type() == Qgis::LayerType::Vector )
       {
         menu->addAction( QgsApplication::getThemeIcon( "/mActionOpenTable.svg" ), tr( "&Open Attribute Table" ), this, &KadasLayerTreeViewMenuProvider::showLayerAttributeTable );
+        menu->addAction( QgsApplication::getThemeIcon( "/mActionFilter2.svg" ), tr( "&Filter…" ), this, &KadasLayerTreeViewMenuProvider::showLayerFilter );
       }
       // For gdi layers, also add info icon
       if ( layer->providerType() == "wms" || layer->providerType() == "arcgismapserver" || layer->providerType() == "arcgisfeatureserver" )
@@ -351,6 +352,11 @@ void KadasLayerTreeViewMenuProvider::setLayerLock( bool enabled )
 void KadasLayerTreeViewMenuProvider::showLayerAttributeTable()
 {
   kApp->showLayerAttributeTable( mView->currentLayer() );
+}
+
+void KadasLayerTreeViewMenuProvider::showLayerFilter()
+{
+  kApp->showLayerFilter( mView->currentLayer() );
 }
 
 void KadasLayerTreeViewMenuProvider::showLayerInfo()

--- a/kadas/app/layertree/kadaslayertreeviewmenuprovider.h
+++ b/kadas/app/layertree/kadaslayertreeviewmenuprovider.h
@@ -41,6 +41,7 @@ class KadasLayerTreeViewMenuProvider : public QObject, public QgsLayerTreeViewMe
     void setLayerUseAsHeightmap( bool enabled );
     void setLayerLock( bool enabled );
     void showLayerAttributeTable();
+    void showLayerFilter();
     void showLayerInfo();
     void showLayerProperties();
 };

--- a/kadas/gui/kadasattributetabledialog.cpp
+++ b/kadas/gui/kadasattributetabledialog.cpp
@@ -26,7 +26,10 @@
 #include <qgis/qgsattributetablemodel.h>
 #include <qgis/qgsdockablewidgethelper.h>
 #include <qgis/qgsexpressionselectiondialog.h>
+#include <qgis/qgsgui.h>
 #include <qgis/qgsmapcanvas.h>
+#include <qgis/qgssubsetstringeditorinterface.h>
+#include <qgis/qgssubsetstringeditorproviderregistry.h>
 #include <qgis/qgsvectorlayer.h>
 #include <qgis/qgsvectorlayercache.h>
 #include <qgis/qgsvectorlayerselectionmanager.h>
@@ -71,6 +74,7 @@ KadasAttributeTableDialog::KadasAttributeTableDialog( QgsVectorLayer *layer, Qgs
   toolbar->addAction( QgsApplication::getThemeIcon( "/mActionDeselectActiveLayer.svg" ), tr( "Deselect all features from the layer" ), this, &KadasAttributeTableDialog::deselectAll );
   toolbar->addAction( QgsApplication::getThemeIcon( "/mActionPanToSelected.svg" ), tr( "Pan map to the selected rows" ), this, &KadasAttributeTableDialog::panToSelected );
   toolbar->addAction( QgsApplication::getThemeIcon( "/mActionZoomToSelected.svg" ), tr( "Zoom map to the selected rows" ), this, &KadasAttributeTableDialog::zoomToSelected );
+  toolbar->addAction( QgsApplication::getThemeIcon( "/mActionFilter2.svg" ), tr( "Filter the features shown in the table" ), this, &KadasAttributeTableDialog::filterFeatures );
   widget->layout()->addWidget( toolbar );
 
   QgsVectorLayerCache *layerCache = new QgsVectorLayerCache( layer, 10000, this );
@@ -151,6 +155,16 @@ void KadasAttributeTableDialog::selectByExpression()
 void KadasAttributeTableDialog::zoomToSelected()
 {
   mCanvas->zoomToSelected( mFeatureSelectionManager->layer() );
+}
+
+void KadasAttributeTableDialog::filterFeatures()
+{
+  std::unique_ptr<QgsSubsetStringEditorInterface> dialog( QgsGui::subsetStringEditorProviderRegistry()->createDialog( mLayer, this ) );
+  if ( !dialog )
+    return;
+
+  dialog->setSubsetString( mLayer->subsetString() );
+  dialog->exec();
 }
 
 void KadasAttributeTableDialog::createFromXml( const QDomElement &element, QgsMapCanvas *canvas, QgsMessageBar *messageBar, QMainWindow *parent = nullptr )

--- a/kadas/gui/kadasattributetabledialog.cpp
+++ b/kadas/gui/kadasattributetabledialog.cpp
@@ -74,7 +74,7 @@ KadasAttributeTableDialog::KadasAttributeTableDialog( QgsVectorLayer *layer, Qgs
   toolbar->addAction( QgsApplication::getThemeIcon( "/mActionDeselectActiveLayer.svg" ), tr( "Deselect all features from the layer" ), this, &KadasAttributeTableDialog::deselectAll );
   toolbar->addAction( QgsApplication::getThemeIcon( "/mActionPanToSelected.svg" ), tr( "Pan map to the selected rows" ), this, &KadasAttributeTableDialog::panToSelected );
   toolbar->addAction( QgsApplication::getThemeIcon( "/mActionZoomToSelected.svg" ), tr( "Zoom map to the selected rows" ), this, &KadasAttributeTableDialog::zoomToSelected );
-  toolbar->addAction( QgsApplication::getThemeIcon( "/mActionFilter2.svg" ), tr( "Filter the features shown in the table" ), this, &KadasAttributeTableDialog::filterFeatures );
+  toolbar->addAction( QgsApplication::getThemeIcon( "/mActionFilter2.svg" ), tr( "Filter the layer by attribute value" ), this, &KadasAttributeTableDialog::filterFeatures );
   widget->layout()->addWidget( toolbar );
 
   QgsVectorLayerCache *layerCache = new QgsVectorLayerCache( layer, 10000, this );
@@ -159,12 +159,13 @@ void KadasAttributeTableDialog::zoomToSelected()
 
 void KadasAttributeTableDialog::filterFeatures()
 {
-  std::unique_ptr<QgsSubsetStringEditorInterface> dialog( QgsGui::subsetStringEditorProviderRegistry()->createDialog( mLayer, this ) );
+  QgsSubsetStringEditorInterface *dialog = QgsGui::subsetStringEditorProviderRegistry()->createDialog( mLayer, this );
   if ( !dialog )
     return;
 
   dialog->setSubsetString( mLayer->subsetString() );
   dialog->exec();
+  delete dialog;
 }
 
 void KadasAttributeTableDialog::createFromXml( const QDomElement &element, QgsMapCanvas *canvas, QgsMessageBar *messageBar, QMainWindow *parent = nullptr )

--- a/kadas/gui/kadasattributetabledialog.cpp
+++ b/kadas/gui/kadasattributetabledialog.cpp
@@ -26,11 +26,10 @@
 #include <qgis/qgsattributetablemodel.h>
 #include <qgis/qgsdockablewidgethelper.h>
 #include <qgis/qgsexpressionselectiondialog.h>
-#include <memory>
 #include <qgis/qgsgui.h>
 #include <qgis/qgsmapcanvas.h>
 #include <qgis/qgssubsetstringeditorinterface.h>
-#include <qgis/qgssubsetstringeditorproviderregistry.h
+#include <qgis/qgssubsetstringeditorproviderregistry.h>
 #include <qgis/qgsvectorlayer.h>
 #include <qgis/qgsvectorlayercache.h>
 #include <qgis/qgsvectorlayerselectionmanager.h>

--- a/kadas/gui/kadasattributetabledialog.cpp
+++ b/kadas/gui/kadasattributetabledialog.cpp
@@ -26,10 +26,11 @@
 #include <qgis/qgsattributetablemodel.h>
 #include <qgis/qgsdockablewidgethelper.h>
 #include <qgis/qgsexpressionselectiondialog.h>
+#include <memory>
 #include <qgis/qgsgui.h>
 #include <qgis/qgsmapcanvas.h>
 #include <qgis/qgssubsetstringeditorinterface.h>
-#include <qgis/qgssubsetstringeditorproviderregistry.h>
+#include <qgis/qgssubsetstringeditorproviderregistry.h
 #include <qgis/qgsvectorlayer.h>
 #include <qgis/qgsvectorlayercache.h>
 #include <qgis/qgsvectorlayerselectionmanager.h>

--- a/kadas/gui/kadasattributetabledialog.h
+++ b/kadas/gui/kadasattributetabledialog.h
@@ -65,6 +65,7 @@ class KADAS_GUI_EXPORT KadasAttributeTableDialog : public QDockWidget
     void panToSelected();
     void selectAll();
     void selectByExpression();
+    void filterFeatures();
     void zoomToSelected();
 };
 


### PR DESCRIPTION
Shortcut to filter layer properties with right click.

Before one had to go into properties and then the query builder to get this dialog.


Reference ticket: https://jira.swisstopo.ch/browse/MGDIGRE_SB-1189 

<img width="1001" height="570" alt="kadas-filter" src="https://github.com/user-attachments/assets/d44f130a-6400-43b3-8d96-f322ab8b7fe9" />
<img width="3700" height="2099" alt="Screenshot from 2026-08-10 11-19-11" src="https://github.com/user-attachments/assets/f9ceab94-e719-4562-9eab-85fe1686d4c5" />
