### PR TITLE
Fix missing auth from second pagination request

### DIFF
--- a/kadas/gui/catalog/kadasarcgisportalcatalogprovider.cpp
+++ b/kadas/gui/catalog/kadasarcgisportalcatalogprovider.cpp
@@ -175,6 +175,7 @@ void KadasArcGisPortalCatalogProvider::replyFinished()
     reqUrl.setQuery( query );
     QNetworkRequest req( reqUrl );
     req.setRawHeader( "Referer", QgsSettings().value( "search/referer", "http://localhost" ).toByteArray() );
+    QgsApplication::authManager()->updateNetworkRequest( req, mAuthId );
     QNetworkReply *reply = QgsNetworkAccessManager::instance()->get( req );
     connect( reply, &QNetworkReply::finished, this, &KadasArcGisPortalCatalogProvider::replyFinished );
   }


### PR DESCRIPTION
This was limiting the amount of layers displayed from private groups to 10.

Tested by swisstopo.