### PR TITLE
Fix annotations could still be edited despited being marked as locked

### DIFF
--- a/kadas/app/layertree/kadaslayertreeviewmenuprovider.cpp
+++ b/kadas/app/layertree/kadaslayertreeviewmenuprovider.cpp
@@ -347,6 +347,12 @@ void KadasLayerTreeViewMenuProvider::setLayerLock( bool enabled )
   {
     vl->setReadOnly( enabled );
   }
+  QgsAnnotationLayer *annoLayer = qobject_cast<QgsAnnotationLayer *>( layer );
+  if ( annoLayer )
+  {
+    // annotation layer are always read only so we cannot rely on it to know if we can edit it.
+    annoLayer->setCustomProperty( QStringLiteral( "readOnly" ), enabled );
+  }
 }
 
 void KadasLayerTreeViewMenuProvider::showLayerAttributeTable()

--- a/kadas/gui/maptools/kadasmaptooleditannotationitem.cpp
+++ b/kadas/gui/maptools/kadasmaptooleditannotationitem.cpp
@@ -449,6 +449,12 @@ void KadasMapToolEditAnnotationItem::canvasPressEvent( QgsMapMouseEvent *e )
   if ( !mItem || !mController || !mLayer )
     return;
 
+  if ( mLayer->customProperty( QStringLiteral( "readOnly" ) ).toBool() )
+  {
+    emit messageEmitted( tr( "Error: %1" ).arg( tr( "Layer is read-only" ) ), Qgis::MessageLevel::Info );
+    return;
+  }
+
   if ( mPressedButton != Qt::NoButton )
     return;
   mPressedButton = e->button();


### PR DESCRIPTION
Since https://github.com/kadas-albireo/kadas-albireo2/pull/476 it was possible to lock and unlock layer via a the context menu in the layer tree.

This PR fix the issue where it was still possible to edit annotations layers via kadas tools