### PR TITLE
3d: adapt to QGIS 4.2 debug flags and background settings API

### DIFF
--- a/kadas/app/3d/kadas3dmapcanvaswidget.cpp
+++ b/kadas/app/3d/kadas3dmapcanvaswidget.cpp
@@ -419,7 +419,7 @@ void Kadas3DMapCanvasWidget::setMapSettings( Qgs3DMapSettings *map )
 
   // Disable button for switching the map theme if the terrain generator is a mesh, or if there is no terrain
   // mActionMapThemes->setDisabled( !mCanvas->mapSettings()->terrainRenderingEnabled() || !mCanvas->mapSettings()->terrainGenerator() || mCanvas->mapSettings()->terrainGenerator()->type() == QgsTerrainGenerator::Mesh );
-  mLabelFpsCounter->setVisible( map->isFpsCounterEnabled() );
+  mLabelFpsCounter->setVisible( map->debugFlags().testFlag( Qgis::Map3DDebugFlag::ShowFPS ) );
 
   connect( map, &Qgs3DMapSettings::viewFrustumVisualizationEnabledChanged, this, &Kadas3DMapCanvasWidget::onViewFrustumVisualizationEnabledChanged );
   connect( map, &Qgs3DMapSettings::extentChanged, this, &Kadas3DMapCanvasWidget::onExtentChanged );

--- a/kadas/app/3d/kadas3dmapconfigwidget.cpp
+++ b/kadas/app/3d/kadas3dmapconfigwidget.cpp
@@ -17,6 +17,8 @@
 
 
 #include "qgs3dmapsettings.h"
+#include "qgsabstract3dmapbackgroundsettings.h"
+#include "qgsskyboxsettings.h"
 #include "qgsdemterrainsettings.h"
 #include "qgsflatterrainsettings.h"
 #include "qgsonlinedemterrainsettings.h"
@@ -93,7 +95,6 @@ Kadas3DMapConfigWidget::Kadas3DMapConfigWidget( Qgs3DMapSettings *map, QgsMapCan
   terrainElevationOffsetSpinBox->setClearValue( 0.0 );
   edlStrengthSpinBox->setClearValue( 1000 );
   edlDistanceSpinBox->setClearValue( 1 );
-  mDebugShadowMapSizeSpinBox->setClearValue( 0.1 );
   mDebugDepthMapSizeSpinBox->setClearValue( 0.1 );
 
   cboTerrainLayer->setAllowEmptyLayer( true );
@@ -169,12 +170,13 @@ Kadas3DMapConfigWidget::Kadas3DMapConfigWidget( Qgs3DMapSettings *map, QgsMapCan
   spinGroundError->setValue( mMap->terrainSettings()->maximumGroundError() );
   terrainElevationOffsetSpinBox->setValue( mMap->terrainSettings()->elevationOffset() );
   chkShowLabels->setChecked( mMap->showLabels() );
-  chkShowTileInfo->setChecked( mMap->showTerrainTilesInfo() );
-  chkShowBoundingBoxes->setChecked( mMap->showTerrainBoundingBoxes() );
-  chkShowCameraViewCenter->setChecked( mMap->showCameraViewCenter() );
-  chkShowCameraRotationCenter->setChecked( mMap->showCameraRotationCenter() );
-  chkShowLightSourceOrigins->setChecked( mMap->showLightSourceOrigins() );
-  mFpsCounterCheckBox->setChecked( mMap->isFpsCounterEnabled() );
+  const Qgis::Map3DDebugFlags debugFlags = mMap->debugFlags();
+  chkShowTileInfo->setChecked( debugFlags.testFlag( Qgis::Map3DDebugFlag::ShowTerrainTileInfo ) );
+  chkShowBoundingBoxes->setChecked( debugFlags.testFlag( Qgis::Map3DDebugFlag::ShowTerrainBoundingBoxes ) );
+  chkShowCameraViewCenter->setChecked( debugFlags.testFlag( Qgis::Map3DDebugFlag::ShowCameraViewCenter ) );
+  chkShowCameraRotationCenter->setChecked( debugFlags.testFlag( Qgis::Map3DDebugFlag::ShowCameraRotationCenter ) );
+  chkShowLightSourceOrigins->setChecked( debugFlags.testFlag( Qgis::Map3DDebugFlag::ShowLightSourceOrigins ) );
+  mFpsCounterCheckBox->setChecked( debugFlags.testFlag( Qgis::Map3DDebugFlag::ShowFPS ) );
 
   mDebugOverlayCheckBox->setChecked( mMap->isDebugOverlayEnabled() );
   mDebugOverlayCheckBox->setVisible( true );
@@ -199,9 +201,12 @@ Kadas3DMapConfigWidget::Kadas3DMapConfigWidget( Qgs3DMapSettings *map, QgsMapCan
   // ==================
   // Page: Skybox
   mSkyboxSettingsWidget = new KadasSkyboxRenderingSettingsWidget( this );
-  mSkyboxSettingsWidget->setSkyboxSettings( map->skyboxSettings() );
+  const QgsAbstract3DMapBackgroundSettings *backgroundSettings = map->backgroundSettings();
+  const bool skyboxEnabled = backgroundSettings && backgroundSettings->type() == Qgis::Map3DBackgroundType::DistinctTextureSkybox;
+  if ( skyboxEnabled )
+    mSkyboxSettingsWidget->setSkyboxSettings( *static_cast<const QgsSkyboxSettings *>( backgroundSettings ) );
   groupSkyboxSettings->layout()->addWidget( mSkyboxSettingsWidget );
-  groupSkyboxSettings->setChecked( mMap->isSkyboxEnabled() );
+  groupSkyboxSettings->setChecked( skyboxEnabled );
 
   // ==================
   // Page: Shadows
@@ -244,20 +249,10 @@ Kadas3DMapConfigWidget::Kadas3DMapConfigWidget( Qgs3DMapSettings *map, QgsMapCan
   edlStrengthSpinBox->setValue( map->eyeDomeLightingStrength() );
   edlDistanceSpinBox->setValue( map->eyeDomeLightingDistance() );
 
-  mDebugShadowMapCornerComboBox->addItem( tr( "Top Left" ) );
-  mDebugShadowMapCornerComboBox->addItem( tr( "Top Right" ) );
-  mDebugShadowMapCornerComboBox->addItem( tr( "Bottom Left" ) );
-  mDebugShadowMapCornerComboBox->addItem( tr( "Bottom Right" ) );
-
   mDebugDepthMapCornerComboBox->addItem( tr( "Top Left" ) );
   mDebugDepthMapCornerComboBox->addItem( tr( "Top Right" ) );
   mDebugDepthMapCornerComboBox->addItem( tr( "Bottom Left" ) );
   mDebugDepthMapCornerComboBox->addItem( tr( "Bottom Right" ) );
-
-  mDebugShadowMapGroupBox->setChecked( map->debugShadowMapEnabled() );
-
-  mDebugShadowMapCornerComboBox->setCurrentIndex( static_cast<int>( map->debugShadowMapCorner() ) );
-  mDebugShadowMapSizeSpinBox->setValue( map->debugShadowMapSize() );
 
   mDebugDepthMapGroupBox->setChecked( map->debugDepthMapEnabled() );
   mDebugDepthMapCornerComboBox->setCurrentIndex( static_cast<int>( map->debugDepthMapCorner() ) );
@@ -364,12 +359,14 @@ void Kadas3DMapConfigWidget::apply()
   mMap->setCameraNavigationMode( mCameraNavigationModeCombo->currentData().value<Qgis::NavigationMode>() );
   mMap->setCameraMovementSpeed( mCameraMovementSpeed->value() );
   mMap->setShowLabels( chkShowLabels->isChecked() );
-  mMap->setShowTerrainTilesInfo( chkShowTileInfo->isChecked() );
-  mMap->setShowTerrainBoundingBoxes( chkShowBoundingBoxes->isChecked() );
-  mMap->setShowCameraViewCenter( chkShowCameraViewCenter->isChecked() );
-  mMap->setShowCameraRotationCenter( chkShowCameraRotationCenter->isChecked() );
-  mMap->setShowLightSourceOrigins( chkShowLightSourceOrigins->isChecked() );
-  mMap->setIsFpsCounterEnabled( mFpsCounterCheckBox->isChecked() );
+  Qgis::Map3DDebugFlags debugFlags = mMap->debugFlags();
+  debugFlags.setFlag( Qgis::Map3DDebugFlag::ShowTerrainTileInfo, chkShowTileInfo->isChecked() );
+  debugFlags.setFlag( Qgis::Map3DDebugFlag::ShowTerrainBoundingBoxes, chkShowBoundingBoxes->isChecked() );
+  debugFlags.setFlag( Qgis::Map3DDebugFlag::ShowCameraViewCenter, chkShowCameraViewCenter->isChecked() );
+  debugFlags.setFlag( Qgis::Map3DDebugFlag::ShowCameraRotationCenter, chkShowCameraRotationCenter->isChecked() );
+  debugFlags.setFlag( Qgis::Map3DDebugFlag::ShowLightSourceOrigins, chkShowLightSourceOrigins->isChecked() );
+  debugFlags.setFlag( Qgis::Map3DDebugFlag::ShowFPS, mFpsCounterCheckBox->isChecked() );
+  mMap->setDebugFlags( debugFlags );
   mMap->setTerrainShadingEnabled( groupTerrainShading->isChecked() );
   mMap->setIsDebugOverlayEnabled( mDebugOverlayCheckBox->isChecked() );
 
@@ -378,8 +375,14 @@ void Kadas3DMapConfigWidget::apply()
     mMap->setTerrainShadingMaterial( *phongMaterial );
 
   mMap->setLightSources( widgetLights->lightSources() );
-  mMap->setIsSkyboxEnabled( groupSkyboxSettings->isChecked() );
-  mMap->setSkyboxSettings( mSkyboxSettingsWidget->toSkyboxSettings() );
+  if ( groupSkyboxSettings->isChecked() )
+  {
+    mMap->setBackgroundSettings( mSkyboxSettingsWidget->toSkyboxSettings().clone() );
+  }
+  else if ( const QgsAbstract3DMapBackgroundSettings *background = mMap->backgroundSettings(); background && background->type() == Qgis::Map3DBackgroundType::DistinctTextureSkybox )
+  {
+    mMap->setBackgroundSettings( nullptr );
+  }
   QgsShadowSettings shadowSettings = mShadowSettingsWidget->toShadowSettings();
   shadowSettings.setRenderShadows( groupShadowRendering->isChecked() );
   mMap->setShadowSettings( shadowSettings );
@@ -397,11 +400,6 @@ void Kadas3DMapConfigWidget::apply()
   mMap->setViewFrustumVisualizationEnabled( mVisualizeExtentCheckBox->isChecked() );
 
   mMap->setDebugDepthMapSettings( mDebugDepthMapGroupBox->isChecked(), static_cast<Qt::Corner>( mDebugDepthMapCornerComboBox->currentIndex() ), mDebugDepthMapSizeSpinBox->value() );
-
-  // Do not display the shadow debug map if the shadow effect is not enabled.
-  mMap->setDebugShadowMapSettings(
-    mDebugShadowMapGroupBox->isChecked() && groupShadowRendering->isChecked(), static_cast<Qt::Corner>( mDebugShadowMapCornerComboBox->currentIndex() ), mDebugShadowMapSizeSpinBox->value()
-  );
 }
 
 void Kadas3DMapConfigWidget::onTerrainTypeChanged()

--- a/kadas/app/ui/map3dconfigwidget.ui
+++ b/kadas/app/ui/map3dconfigwidget.ui
@@ -1145,51 +1145,6 @@
                     </item>
                    </layout>
                   </item>
-                  <item row="1" column="0">
-                   <widget class="QGroupBox" name="mDebugShadowMapGroupBox">
-                    <property name="title">
-                     <string>Debug Shadow Map</string>
-                    </property>
-                    <property name="checkable">
-                     <bool>true</bool>
-                    </property>
-                    <property name="checked">
-                     <bool>false</bool>
-                    </property>
-                    <layout class="QGridLayout" name="gridLayout_10">
-                     <item row="0" column="1">
-                      <widget class="QComboBox" name="mDebugShadowMapCornerComboBox"/>
-                     </item>
-                     <item row="0" column="0">
-                      <widget class="QLabel" name="label_8">
-                       <property name="text">
-                        <string>Corner</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="1" column="0">
-                      <widget class="QLabel" name="label_10">
-                       <property name="text">
-                        <string>Size</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="1" column="1">
-                      <widget class="QgsDoubleSpinBox" name="mDebugShadowMapSizeSpinBox">
-                       <property name="maximum">
-                        <double>1.000000000000000</double>
-                       </property>
-                       <property name="singleStep">
-                        <double>0.100000000000000</double>
-                       </property>
-                       <property name="value">
-                        <double>0.100000000000000</double>
-                       </property>
-                      </widget>
-                     </item>
-                    </layout>
-                   </widget>
-                  </item>
                   <item row="3" column="0">
                    <spacer name="verticalSpacerAdvanced">
                     <property name="orientation">
@@ -1305,9 +1260,6 @@
   <tabstop>edlGroupBox</tabstop>
   <tabstop>edlStrengthSpinBox</tabstop>
   <tabstop>edlDistanceSpinBox</tabstop>
-  <tabstop>mDebugShadowMapGroupBox</tabstop>
-  <tabstop>mDebugShadowMapCornerComboBox</tabstop>
-  <tabstop>mDebugShadowMapSizeSpinBox</tabstop>
   <tabstop>mDebugDepthMapGroupBox</tabstop>
   <tabstop>mDebugDepthMapCornerComboBox</tabstop>
   <tabstop>mDebugDepthMapSizeSpinBox</tabstop>


### PR DESCRIPTION
Replace the deprecated per-option 3D debug accessors (terrain tile info, terrain bounding boxes, camera view/rotation center, light source origins, FPS counter) with Qgs3DMapSettings::debugFlags()/setDebugFlags(). The flags are read back before applying so bits not exposed in the UI are preserved.

Skybox configuration moves to backgroundSettings()/setBackgroundSettings(): QgsSkyboxSettings is now a QgsAbstract3DMapBackgroundSettings subclass, so "skybox enabled" becomes a background of type DistinctTextureSkybox. The background is only cleared when it actually is a skybox.

Shadow map debugging is no longer supported by QGIS, so drop the Debug Shadow Map group box and its handling. Depth map debugging is unchanged.