### PR TITLE
update to Qt 6 enum in UI file

### DIFF
--- a/kadas/app/bullseye/kadasbullseyewidgetbase.ui
+++ b/kadas/app/bullseye/kadasbullseyewidgetbase.ui
@@ -39,7 +39,7 @@
    <item>
     <widget class="Line" name="line">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
     </widget>
    </item>
@@ -261,7 +261,7 @@
    <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>

--- a/kadas/app/guidegrid/kadasguidegridwidgetbase.ui
+++ b/kadas/app/guidegrid/kadasguidegridwidgetbase.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>320</width>
+    <width>381</width>
     <height>400</height>
    </rect>
   </property>
@@ -36,7 +36,7 @@
    <item>
     <widget class="Line" name="line">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
     </widget>
    </item>
@@ -47,7 +47,7 @@
      </property>
      <layout class="QFormLayout" name="formLayout">
       <property name="fieldGrowthPolicy">
-       <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+       <enum>QFormLayout::FieldGrowthPolicy::AllNonFixedFieldsGrow</enum>
       </property>
       <property name="leftMargin">
        <number>0</number>
@@ -76,14 +76,14 @@
         <item>
          <widget class="QLineEdit" name="lineEditTopLeft">
           <property name="alignment">
-           <set>Qt::AlignCenter</set>
+           <set>Qt::AlignmentFlag::AlignCenter</set>
           </property>
          </widget>
         </item>
         <item>
          <widget class="QToolButton" name="toolButtonPickTopLeft">
           <property name="icon">
-           <iconset resource="../../resources/resources.qrc">
+           <iconset>
             <normaloff>:/kadas/icons/pick</normaloff>:/kadas/icons/pick</iconset>
           </property>
          </widget>
@@ -105,14 +105,14 @@
         <item>
          <widget class="QLineEdit" name="lineEditBottomRight">
           <property name="alignment">
-           <set>Qt::AlignCenter</set>
+           <set>Qt::AlignmentFlag::AlignCenter</set>
           </property>
          </widget>
         </item>
         <item>
          <widget class="QToolButton" name="toolButtonPickBottomRight">
           <property name="icon">
-           <iconset resource="../../resources/resources.qrc">
+           <iconset>
             <normaloff>:/kadas/icons/pick</normaloff>:/kadas/icons/pick</iconset>
           </property>
          </widget>
@@ -197,7 +197,7 @@
         <item>
          <widget class="QToolButton" name="toolButtonLockWidth">
           <property name="icon">
-           <iconset resource="../../resources/resources.qrc">
+           <iconset>
             <normaloff>:/kadas/icons/unlocked</normaloff>:/kadas/icons/unlocked</iconset>
           </property>
           <property name="checkable">
@@ -231,7 +231,7 @@
         <item>
          <widget class="QToolButton" name="toolButtonLockHeight">
           <property name="icon">
-           <iconset resource="../../resources/resources.qrc">
+           <iconset>
             <normaloff>:/kadas/icons/unlocked</normaloff>:/kadas/icons/unlocked</iconset>
           </property>
           <property name="checkable">
@@ -318,7 +318,7 @@
           <item>
            <widget class="QToolButton" name="toolButtonSwitchLabels">
             <property name="icon">
-             <iconset resource="../../resources/resources.qrc">
+             <iconset>
               <normaloff>:/kadas/icons/switch</normaloff>:/kadas/icons/switch</iconset>
             </property>
            </widget>
@@ -349,7 +349,7 @@
    <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
@@ -365,7 +365,7 @@
   <customwidget>
    <class>QgsColorButton</class>
    <extends>QToolButton</extends>
-   <header location="global">qgis/qgscolorbutton.h</header>
+   <header>qgscolorbutton.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/kadas/app/kml/kadaskmlexportdialogbase.ui
+++ b/kadas/app/kml/kadaskmlexportdialogbase.ui
@@ -51,7 +51,7 @@
    <item row="2" column="0" colspan="4">
     <widget class="Line" name="line">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
     </widget>
    </item>
@@ -214,7 +214,7 @@
    <item row="11" column="0" colspan="4">
     <widget class="QDialogButtonBox" name="mButtonBox">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
      <property name="standardButtons">
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
@@ -224,7 +224,7 @@
    <item row="10" column="0" colspan="4">
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>

--- a/kadas/app/mapgrid/kadasmapgridwidgetbase.ui
+++ b/kadas/app/mapgrid/kadasmapgridwidgetbase.ui
@@ -36,7 +36,7 @@
    <item>
     <widget class="Line" name="line">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
     </widget>
    </item>
@@ -194,7 +194,7 @@
    <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>

--- a/kadas/app/ui/kadaspluginmanager.ui
+++ b/kadas/app/ui/kadaspluginmanager.ui
@@ -79,7 +79,7 @@
    <item row="2" column="2">
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>

--- a/kadas/app/ui/map3dconfigwidget.ui
+++ b/kadas/app/ui/map3dconfigwidget.ui
@@ -32,7 +32,7 @@
    <item>
     <widget class="QSplitter" name="m3DOptionsSplitter">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
      <property name="childrenCollapsible">
       <bool>false</bool>
@@ -244,7 +244,7 @@
                <item>
                 <spacer name="verticalSpacer">
                  <property name="orientation">
-                  <enum>Qt::Vertical</enum>
+                  <enum>Qt::Orientation::Vertical</enum>
                  </property>
                  <property name="sizeHint" stdset="0">
                   <size>
@@ -459,7 +459,7 @@
                <item>
                 <spacer name="verticalSpacerTerrain">
                  <property name="orientation">
-                  <enum>Qt::Vertical</enum>
+                  <enum>Qt::Orientation::Vertical</enum>
                  </property>
                  <property name="sizeHint" stdset="0">
                   <size>
@@ -543,7 +543,7 @@
                <item>
                 <spacer name="verticalSpacerLights">
                  <property name="orientation">
-                  <enum>Qt::Vertical</enum>
+                  <enum>Qt::Orientation::Vertical</enum>
                  </property>
                  <property name="sizeHint" stdset="0">
                   <size>
@@ -688,7 +688,7 @@
                <item>
                 <spacer name="verticalSpacerShadow">
                  <property name="orientation">
-                  <enum>Qt::Vertical</enum>
+                  <enum>Qt::Orientation::Vertical</enum>
                  </property>
                  <property name="sizeHint" stdset="0">
                   <size>
@@ -900,7 +900,7 @@
                <item>
                 <spacer name="verticalSpacerCameraSkybox">
                  <property name="orientation">
-                  <enum>Qt::Vertical</enum>
+                  <enum>Qt::Orientation::Vertical</enum>
                  </property>
                  <property name="sizeHint" stdset="0">
                   <size>
@@ -1148,7 +1148,7 @@
                   <item row="3" column="0">
                    <spacer name="verticalSpacerAdvanced">
                     <property name="orientation">
-                     <enum>Qt::Vertical</enum>
+                     <enum>Qt::Orientation::Vertical</enum>
                     </property>
                     <property name="sizeHint" stdset="0">
                      <size>

--- a/kadas/gui/ui/kadaslayerpropertiesdialog.ui
+++ b/kadas/gui/ui/kadaslayerpropertiesdialog.ui
@@ -23,7 +23,7 @@
    <item>
     <widget class="QSplitter" name="mOptionsSplitter">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
      <property name="childrenCollapsible">
       <bool>false</bool>
@@ -36,10 +36,10 @@
        </size>
       </property>
       <property name="frameShape">
-       <enum>QFrame::NoFrame</enum>
+       <enum>QFrame::Shape::NoFrame</enum>
       </property>
       <property name="frameShadow">
-       <enum>QFrame::Raised</enum>
+       <enum>QFrame::Shadow::Raised</enum>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_2">
        <property name="leftMargin">
@@ -69,10 +69,10 @@
           </size>
          </property>
          <property name="horizontalScrollBarPolicy">
-          <enum>Qt::ScrollBarAlwaysOff</enum>
+          <enum>Qt::ScrollBarPolicy::ScrollBarAlwaysOff</enum>
          </property>
          <property name="editTriggers">
-          <set>QAbstractItemView::NoEditTriggers</set>
+          <set>QAbstractItemView::EditTrigger::NoEditTriggers</set>
          </property>
          <property name="iconSize">
           <size>
@@ -81,10 +81,10 @@
           </size>
          </property>
          <property name="textElideMode">
-          <enum>Qt::ElideNone</enum>
+          <enum>Qt::TextElideMode::ElideNone</enum>
          </property>
          <property name="resizeMode">
-          <enum>QListView::Adjust</enum>
+          <enum>QListView::ResizeMode::Adjust</enum>
          </property>
          <property name="wordWrap">
           <bool>true</bool>
@@ -101,10 +101,10 @@
        </sizepolicy>
       </property>
       <property name="frameShape">
-       <enum>QFrame::NoFrame</enum>
+       <enum>QFrame::Shape::NoFrame</enum>
       </property>
       <property name="frameShadow">
-       <enum>QFrame::Raised</enum>
+       <enum>QFrame::Shadow::Raised</enum>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_3">
        <property name="leftMargin">
@@ -145,10 +145,10 @@
       </sizepolicy>
      </property>
      <property name="frameShape">
-      <enum>QFrame::NoFrame</enum>
+      <enum>QFrame::Shape::NoFrame</enum>
      </property>
      <property name="frameShadow">
-      <enum>QFrame::Raised</enum>
+      <enum>QFrame::Shadow::Raised</enum>
      </property>
      <layout class="QGridLayout" name="gridLayout_btnbox">
       <property name="leftMargin">
@@ -166,10 +166,10 @@
       <item row="2" column="1" colspan="4">
        <widget class="QDialogButtonBox" name="mButtonBox">
         <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+         <enum>Qt::Orientation::Horizontal</enum>
         </property>
         <property name="standardButtons">
-         <set>QDialogButtonBox::Apply|QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+         <set>QDialogButtonBox::StandardButton::Apply|QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Ok</set>
         </property>
        </widget>
       </item>

--- a/kadas/gui/ui/kadasprojecttemplateselectiondialog.ui
+++ b/kadas/gui/ui/kadasprojecttemplateselectiondialog.ui
@@ -48,7 +48,7 @@
    <item>
     <widget class="QDialogButtonBox" name="mButtonBox">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
      <property name="standardButtons">
       <set>QDialogButtonBox::Cancel</set>

--- a/share/python/plugins/kadas_gpkg/kadas_gpkg_export_dialog.ui
+++ b/share/python/plugins/kadas_gpkg/kadas_gpkg_export_dialog.ui
@@ -226,7 +226,7 @@
    <item row="10" column="1">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
      <property name="standardButtons">
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>

--- a/share/python/plugins/kadas_print/ui/cartouchedialog.ui
+++ b/share/python/plugins/kadas_print/ui/cartouchedialog.ui
@@ -3,7 +3,7 @@
  <class>CartoucheDialog</class>
  <widget class="QDialog" name="CartoucheDialog">
   <property name="windowModality">
-   <enum>Qt::ApplicationModal</enum>
+   <enum>Qt::WindowModality::ApplicationModal</enum>
   </property>
   <property name="geometry">
    <rect>
@@ -23,10 +23,10 @@
       <bool>false</bool>
      </property>
      <property name="verticalScrollBarPolicy">
-      <enum>Qt::ScrollBarAlwaysOff</enum>
+      <enum>Qt::ScrollBarPolicy::ScrollBarAlwaysOff</enum>
      </property>
      <property name="horizontalScrollBarPolicy">
-      <enum>Qt::ScrollBarAlwaysOff</enum>
+      <enum>Qt::ScrollBarPolicy::ScrollBarAlwaysOff</enum>
      </property>
     </widget>
    </item>
@@ -45,10 +45,10 @@
       <item>
        <widget class="QFrame" name="frame">
         <property name="frameShape">
-         <enum>QFrame::StyledPanel</enum>
+         <enum>QFrame::Shape::StyledPanel</enum>
         </property>
         <property name="frameShadow">
-         <enum>QFrame::Raised</enum>
+         <enum>QFrame::Shadow::Raised</enum>
         </property>
         <layout class="QGridLayout" name="gridLayout_3">
          <item row="1" column="0">
@@ -105,20 +105,20 @@
    <item row="18" column="0">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Close</set>
+      <set>QDialogButtonBox::StandardButton::Close</set>
      </property>
     </widget>
    </item>
    <item row="1" column="0">
     <widget class="QFrame" name="frame_2">
      <property name="frameShape">
-      <enum>QFrame::StyledPanel</enum>
+      <enum>QFrame::Shape::StyledPanel</enum>
      </property>
      <property name="frameShadow">
-      <enum>QFrame::Raised</enum>
+      <enum>QFrame::Shadow::Raised</enum>
      </property>
      <layout class="QGridLayout" name="gridLayout_4">
       <item row="5" column="0" colspan="2">

--- a/share/python/plugins/kadas_print/ui/printdialog.ui
+++ b/share/python/plugins/kadas_print/ui/printdialog.ui
@@ -393,10 +393,10 @@
       <bool>false</bool>
      </property>
      <property name="verticalScrollBarPolicy">
-      <enum>Qt::ScrollBarAlwaysOff</enum>
+      <enum>Qt::ScrollBarPolicy::ScrollBarAlwaysOff</enum>
      </property>
      <property name="horizontalScrollBarPolicy">
-      <enum>Qt::ScrollBarAlwaysOff</enum>
+      <enum>Qt::ScrollBarPolicy::ScrollBarAlwaysOff</enum>
      </property>
      <property name="interactive">
       <bool>false</bool>
@@ -416,10 +416,10 @@
    <item row="15" column="0" colspan="3">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Close</set>
+      <set>QDialogButtonBox::StandardButton::Close</set>
      </property>
     </widget>
    </item>

--- a/share/python/plugins/kadas_print/ui/printlayoutmanager.ui
+++ b/share/python/plugins/kadas_print/ui/printlayoutmanager.ui
@@ -47,7 +47,7 @@
    <item row="2" column="0" colspan="3">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
      <property name="standardButtons">
       <set>QDialogButtonBox::Close</set>


### PR DESCRIPTION
This PR update .ui file to use Qt6 enums style.

It worked before this PR, but the sole purpose of this PR is to avoid unrelated noise in future PR. Because each time we would modify a .ui file in recent Qt Designer/Qt Creator version it would save with the new enum style. 