### PR TITLE
Improvements to Guide Grid annotation

### DIFF
--- a/kadas/app/CMakeLists.txt
+++ b/kadas/app/CMakeLists.txt
@@ -51,6 +51,7 @@ set(kadas_SRC
     external/qgis/app/qgslayertreeviewnonremovableindicator.cpp
     external/qgis/app/3d/qgsmaterialpreviewwidget.cpp
     guidegrid/kadasguidegridlayer.cpp
+    guidegrid/kadasguidegridutils.cpp
     guidegrid/kadasmaptoolguidegrid.cpp
     iamauth/kadasiamauth.cpp
     kml/kadaskmlexport.cpp
@@ -121,6 +122,7 @@ set(kadas_HDR
     external/qgis/app/3d/qgsmaterial3dhandler.h
     external/qgis/app/3d/qgsmaterialpreviewwidget.h
     guidegrid/kadasguidegridlayer.h
+    guidegrid/kadasguidegridutils.h
     guidegrid/kadasmaptoolguidegrid.h
     iamauth/kadasiamauth.h
     kml/kadaskmlexport.h

--- a/kadas/app/guidegrid/kadasguidegridlayer.cpp
+++ b/kadas/app/guidegrid/kadasguidegridlayer.cpp
@@ -35,55 +35,7 @@
 #include <qgis/qgstextformat.h>
 
 #include <guidegrid/kadasguidegridlayer.h>
-
-namespace
-{
-  QString gridLabel( const QString firstStart, int offset, bool avoidRepeatingLetters = false )
-  {
-    bool isInt = false;
-    int startNumber = firstStart.toInt( &isInt );
-    if ( isInt )
-    {
-      return QString::number( startNumber + offset );
-    }
-
-    // Convert to decimal base
-    int startOffset = 0;
-    for ( int i = 0; i < firstStart.length(); ++i )
-    {
-      QChar c = firstStart.at( i );
-      startOffset = startOffset * 26 + ( c.toLatin1() - 'A' + 1 );
-    }
-
-    int skipped = 0;
-    if ( avoidRepeatingLetters )
-    {
-      for ( int i = 0; i <= offset; i++ )
-      {
-        QString lbl = gridLabel( firstStart, i );
-        QChar firstChar = lbl.at( 0 );
-        bool isRepeating = std::all_of( lbl.begin(), lbl.end(), [firstChar]( QChar c ) { return c == firstChar; } );
-
-        if ( lbl.length() != 1 && isRepeating )
-        {
-          skipped++;
-        }
-      }
-    }
-
-    offset += startOffset + skipped;
-
-    QString label;
-    do
-    {
-      offset -= 1;
-      int res = offset % 26;
-      label.prepend( QChar( 'A' + res ) );
-      offset /= 26;
-    } while ( offset > 0 );
-    return label;
-  }
-} // namespace
+#include "guidegrid/kadasguidegridutils.h"
 
 
 /// Kadas-only QPainter-based renderer that preserves the dynamic
@@ -164,7 +116,7 @@ class KadasGuideGridRenderer : public QgsMapLayerRenderer
         {
           const double sx1 = vLine1.first().x();
           const double sx2 = vLine2.first().x();
-          const QString label = gridLabel( mGridConfig.colStart, col - 1, mGridConfig.avoidRepeatingLetters );
+          const QString label = KadasGuideGridUtils::gridLabel( mGridConfig.colStart, col - 1, mGridConfig.avoidRepeatingLetters );
           if ( mGridConfig.labelingPos == LabelingPos::LabelsOutside && vLine1.first().y() - labelBoxSize > screenRect.top() )
             drawGridLabel( 0.5 * ( sx1 + sx2 ), sy1 - 0.5 * labelBoxSize, label, font, fontMetrics, bufferColor );
           else if ( sy1 < vLine1.last().y() - 2 * labelBoxSize )
@@ -228,7 +180,7 @@ class KadasGuideGridRenderer : public QgsMapLayerRenderer
         {
           const double sy1h = hLine1.first().y();
           const double sy2h = hLine2.first().y();
-          const QString label = gridLabel( mGridConfig.rowStart, row - 1, mGridConfig.avoidRepeatingLetters );
+          const QString label = KadasGuideGridUtils::gridLabel( mGridConfig.rowStart, row - 1, mGridConfig.avoidRepeatingLetters );
           if ( mGridConfig.labelingPos == LabelingPos::LabelsOutside && hLine1.first().x() - labelBoxSize > screenRect.left() )
             drawGridLabel( sx1 - 0.5 * labelBoxSize, 0.5 * ( sy1h + sy2h ), label, font, fontMetrics, bufferColor );
           else if ( sx1 < hLine1.last().x() - 2 * labelBoxSize )
@@ -379,7 +331,9 @@ QList<KadasPluginLayer::IdentifyResult> KadasGuideGridLayer::identify( const Qgs
   bbox->setExteriorRing( ring );
   QMap<QString, QVariant> attrs;
 
-  QString text = tr( "Cell %1, %2" ).arg( gridLabel( mGridConfig.rowStart, j, mGridConfig.avoidRepeatingLetters ) ).arg( gridLabel( mGridConfig.colStart.at( 0 ), i, mGridConfig.avoidRepeatingLetters ) );
+  QString text = tr( "Cell %1, %2" )
+                   .arg( KadasGuideGridUtils::gridLabel( mGridConfig.rowStart, j, mGridConfig.avoidRepeatingLetters ) )
+                   .arg( KadasGuideGridUtils::gridLabel( mGridConfig.colStart.at( 0 ), i, mGridConfig.avoidRepeatingLetters ) );
   if ( mGridConfig.quadrantLabeling != QuadrantLabeling::DontLabelQuadrants )
   {
     bool left = pos.x() <= mGridConfig.gridRect.xMinimum() + ( i + 0.5 ) * colWidth;
@@ -573,7 +527,7 @@ void KadasGuideGridLayer::regenerate()
   // --- Column labels (top + bottom of the grid rect) ---
   for ( int col = 0; col < mGridConfig.cols; ++col )
   {
-    const QString label = gridLabel( mGridConfig.colStart, col, mGridConfig.avoidRepeatingLetters );
+    const QString label = KadasGuideGridUtils::gridLabel( mGridConfig.colStart, col, mGridConfig.avoidRepeatingLetters );
     const double cx = r.xMinimum() + ( col + 0.5 ) * dx;
     // Top
     {
@@ -596,7 +550,7 @@ void KadasGuideGridLayer::regenerate()
   // --- Row labels (left + right of the grid rect) ---
   for ( int row = 0; row < mGridConfig.rows; ++row )
   {
-    const QString label = gridLabel( mGridConfig.rowStart, row, mGridConfig.avoidRepeatingLetters );
+    const QString label = KadasGuideGridUtils::gridLabel( mGridConfig.rowStart, row, mGridConfig.avoidRepeatingLetters );
     const double cy = r.yMaximum() - ( row + 0.5 ) * dy;
     // Left
     {

--- a/kadas/app/guidegrid/kadasguidegridlayer.cpp
+++ b/kadas/app/guidegrid/kadasguidegridlayer.cpp
@@ -38,15 +38,25 @@
 
 namespace
 {
-  QString gridLabel( QString firstStart, int offset )
+  QString gridLabel( const QString firstStart, int offset )
   {
-    QChar firstChar = firstStart.at( 0 );
-    if ( firstChar >= '0' && firstChar <= '9' )
+    bool isInt = false;
+    int startNumber = firstStart.toInt( &isInt );
+    if ( isInt )
     {
-      return QString::number( firstChar.digitValue() + offset );
+      return QString::number( startNumber + offset );
     }
+
+    // Convert to decimal base
+    int startOffset = 0;
+    for ( int i = 0; i < firstStart.length(); ++i )
+    {
+      QChar c = firstStart.at( i );
+      startOffset = startOffset * 26 + ( c.toLatin1() - 'A' + 1 );
+    }
+    offset += startOffset;
+
     QString label;
-    offset += firstChar.toLatin1() - 'A' + 1;
     do
     {
       offset -= 1;

--- a/kadas/app/guidegrid/kadasguidegridlayer.cpp
+++ b/kadas/app/guidegrid/kadasguidegridlayer.cpp
@@ -38,7 +38,7 @@
 
 namespace
 {
-  QString gridLabel( const QString firstStart, int offset )
+  QString gridLabel( const QString firstStart, int offset, bool avoidRepeatingLetters = false )
   {
     bool isInt = false;
     int startNumber = firstStart.toInt( &isInt );
@@ -54,7 +54,24 @@ namespace
       QChar c = firstStart.at( i );
       startOffset = startOffset * 26 + ( c.toLatin1() - 'A' + 1 );
     }
-    offset += startOffset;
+
+    int skipped = 0;
+    if ( avoidRepeatingLetters )
+    {
+      for ( int i = 0; i <= offset; i++ )
+      {
+        QString lbl = gridLabel( firstStart, i );
+        QChar firstChar = lbl.at( 0 );
+        bool isRepeating = std::all_of( lbl.begin(), lbl.end(), [firstChar]( QChar c ) { return c == firstChar; } );
+
+        if ( lbl.length() != 1 && isRepeating )
+        {
+          skipped++;
+        }
+      }
+    }
+
+    offset += startOffset + skipped;
 
     QString label;
     do
@@ -147,7 +164,7 @@ class KadasGuideGridRenderer : public QgsMapLayerRenderer
         {
           const double sx1 = vLine1.first().x();
           const double sx2 = vLine2.first().x();
-          const QString label = gridLabel( mGridConfig.colStart, col - 1 );
+          const QString label = gridLabel( mGridConfig.colStart, col - 1, mGridConfig.avoidRepeatingLetters );
           if ( mGridConfig.labelingPos == LabelingPos::LabelsOutside && vLine1.first().y() - labelBoxSize > screenRect.top() )
             drawGridLabel( 0.5 * ( sx1 + sx2 ), sy1 - 0.5 * labelBoxSize, label, font, fontMetrics, bufferColor );
           else if ( sy1 < vLine1.last().y() - 2 * labelBoxSize )
@@ -211,7 +228,7 @@ class KadasGuideGridRenderer : public QgsMapLayerRenderer
         {
           const double sy1h = hLine1.first().y();
           const double sy2h = hLine2.first().y();
-          const QString label = gridLabel( mGridConfig.rowStart, row - 1 );
+          const QString label = gridLabel( mGridConfig.rowStart, row - 1, mGridConfig.avoidRepeatingLetters );
           if ( mGridConfig.labelingPos == LabelingPos::LabelsOutside && hLine1.first().x() - labelBoxSize > screenRect.left() )
             drawGridLabel( sx1 - 0.5 * labelBoxSize, 0.5 * ( sy1h + sy2h ), label, font, fontMetrics, bufferColor );
           else if ( sx1 < hLine1.last().x() - 2 * labelBoxSize )
@@ -362,7 +379,7 @@ QList<KadasPluginLayer::IdentifyResult> KadasGuideGridLayer::identify( const Qgs
   bbox->setExteriorRing( ring );
   QMap<QString, QVariant> attrs;
 
-  QString text = tr( "Cell %1, %2" ).arg( gridLabel( mGridConfig.rowStart, j ) ).arg( gridLabel( mGridConfig.colStart.at( 0 ), i ) );
+  QString text = tr( "Cell %1, %2" ).arg( gridLabel( mGridConfig.rowStart, j, mGridConfig.avoidRepeatingLetters ) ).arg( gridLabel( mGridConfig.colStart.at( 0 ), i, mGridConfig.avoidRepeatingLetters ) );
   if ( mGridConfig.quadrantLabeling != QuadrantLabeling::DontLabelQuadrants )
   {
     bool left = pos.x() <= mGridConfig.gridRect.xMinimum() + ( i + 0.5 ) * colWidth;
@@ -406,6 +423,7 @@ bool KadasGuideGridLayer::readXml( const QDomNode &layer_node, QgsReadWriteConte
     mGridConfig.colStart = colStart.isEmpty() ? QString( "1" ) : colStart;
     mGridConfig.labelingPos = static_cast<LabelingPos>( customProperty( QStringLiteral( "kadas/guidegrid/labelingPos" ) ).toInt() );
     mGridConfig.quadrantLabeling = static_cast<QuadrantLabeling>( customProperty( QStringLiteral( "kadas/guidegrid/quadrantLabeling" ) ).toInt() );
+    mGridConfig.avoidRepeatingLetters = customProperty( QStringLiteral( "kadas/guidegrid/avoidRepeatingLetters" ) ).toBool();
     regenerate();
     return true;
   }
@@ -432,6 +450,7 @@ bool KadasGuideGridLayer::readXml( const QDomNode &layer_node, QgsReadWriteConte
   mGridConfig.colStart = !cfgEl.attribute( "colChar" ).isEmpty() ? cfgEl.attribute( "colChar" ).at( 0 ) : '1';
   mGridConfig.labelingPos = static_cast<LabelingPos>( cfgEl.attribute( "labelingPos" ).toInt() );
   mGridConfig.quadrantLabeling = static_cast<QuadrantLabeling>( cfgEl.attribute( "quadrantLabeling" ).toInt() );
+  mGridConfig.avoidRepeatingLetters = false; // Legacy didn't have this option, set to false same as default.
 
   // Base readXml replaced all customProperties from the (legacy, marker-less)
   // XML; re-assert the parametric marker set by the constructor.
@@ -468,6 +487,7 @@ void KadasGuideGridLayer::writeConfigToCustomProperties()
   setCustomProperty( QStringLiteral( "kadas/guidegrid/colChar" ), QString( mGridConfig.colStart ) );
   setCustomProperty( QStringLiteral( "kadas/guidegrid/labelingPos" ), static_cast<int>( mGridConfig.labelingPos ) );
   setCustomProperty( QStringLiteral( "kadas/guidegrid/quadrantLabeling" ), static_cast<int>( mGridConfig.quadrantLabeling ) );
+  setCustomProperty( QStringLiteral( "kadas/guidegrid/avoidRepeatingLetters" ), mGridConfig.avoidRepeatingLetters );
 }
 
 void KadasGuideGridLayer::regenerate()
@@ -553,7 +573,7 @@ void KadasGuideGridLayer::regenerate()
   // --- Column labels (top + bottom of the grid rect) ---
   for ( int col = 0; col < mGridConfig.cols; ++col )
   {
-    const QString label = gridLabel( mGridConfig.colStart, col );
+    const QString label = gridLabel( mGridConfig.colStart, col, mGridConfig.avoidRepeatingLetters );
     const double cx = r.xMinimum() + ( col + 0.5 ) * dx;
     // Top
     {
@@ -576,7 +596,7 @@ void KadasGuideGridLayer::regenerate()
   // --- Row labels (left + right of the grid rect) ---
   for ( int row = 0; row < mGridConfig.rows; ++row )
   {
-    const QString label = gridLabel( mGridConfig.rowStart, row );
+    const QString label = gridLabel( mGridConfig.rowStart, row, mGridConfig.avoidRepeatingLetters );
     const double cy = r.yMaximum() - ( row + 0.5 ) * dy;
     // Left
     {

--- a/kadas/app/guidegrid/kadasguidegridlayer.cpp
+++ b/kadas/app/guidegrid/kadasguidegridlayer.cpp
@@ -77,10 +77,6 @@ namespace
 class KadasGuideGridRenderer : public QgsMapLayerRenderer
 {
   public:
-    using GridConfig = KadasGuideGridLayer::GridConfig;
-    using LabelingPos = KadasGuideGridLayer::LabelingPos;
-    using QuadrantLabeling = KadasGuideGridLayer::QuadrantLabeling;
-
     KadasGuideGridRenderer( KadasGuideGridLayer *layer, QgsRenderContext &rendererContext )
       : QgsMapLayerRenderer( layer->id(), &rendererContext )
       , mGridConfig( layer->mGridConfig )
@@ -152,17 +148,17 @@ class KadasGuideGridRenderer : public QgsMapLayerRenderer
           const double sx1 = vLine1.first().x();
           const double sx2 = vLine2.first().x();
           const QString label = gridLabel( mGridConfig.colStart, col - 1 );
-          if ( mGridConfig.labelingPos == KadasGuideGridLayer::LabelsOutside && vLine1.first().y() - labelBoxSize > screenRect.top() )
+          if ( mGridConfig.labelingPos == LabelingPos::LabelsOutside && vLine1.first().y() - labelBoxSize > screenRect.top() )
             drawGridLabel( 0.5 * ( sx1 + sx2 ), sy1 - 0.5 * labelBoxSize, label, font, fontMetrics, bufferColor );
           else if ( sy1 < vLine1.last().y() - 2 * labelBoxSize )
             drawGridLabel( 0.5 * ( sx1 + sx2 ), sy1 + 0.5 * labelBoxSize, label, font, fontMetrics, bufferColor );
-          if ( mGridConfig.labelingPos == KadasGuideGridLayer::LabelsOutside && vLine1.last().y() + labelBoxSize < screenRect.bottom() )
+          if ( mGridConfig.labelingPos == LabelingPos::LabelsOutside && vLine1.last().y() + labelBoxSize < screenRect.bottom() )
             drawGridLabel( 0.5 * ( sx1 + sx2 ), sy2 + 0.5 * labelBoxSize, label, font, fontMetrics, bufferColor );
           else if ( sy2 > vLine1.first().y() + 2 * labelBoxSize )
             drawGridLabel( 0.5 * ( sx1 + sx2 ), sy2 - 0.5 * labelBoxSize, label, font, fontMetrics, bufferColor );
         }
 
-        if ( quadrantLabeling != KadasGuideGridLayer::DontLabelQuadrants )
+        if ( quadrantLabeling != QuadrantLabeling::DontLabelQuadrants )
         {
           p->save();
           p->setPen( QPen( mGridConfig.color, mGridConfig.lineWidth, Qt::DashLine ) );
@@ -177,10 +173,10 @@ class KadasGuideGridRenderer : public QgsMapLayerRenderer
               drawGridLabel( vLine1.at( i + 1 ).x() + 0.5 * smallLabelBoxSize, vLine1.at( i + 1 ).y() - 0.5 * smallLabelBoxSize, "D", smallFont, smallFontMetrics, bufferColor );
               drawGridLabel( vLine2.at( i + 1 ).x() - 0.5 * smallLabelBoxSize, vLine2.at( i + 1 ).y() - 0.5 * smallLabelBoxSize, "C", smallFont, smallFontMetrics, bufferColor );
             }
-            if ( quadrantLabeling == KadasGuideGridLayer::LabelOneQuadrant )
+            if ( quadrantLabeling == QuadrantLabeling::LabelOneQuadrant )
             {
               vLineMid.append( 0.5 * ( vLine1.at( i + 1 ) + vLine2.at( i + 1 ) ) );
-              quadrantLabeling = KadasGuideGridLayer::DontLabelQuadrants;
+              quadrantLabeling = QuadrantLabeling::DontLabelQuadrants;
               break;
             }
           }
@@ -216,26 +212,26 @@ class KadasGuideGridRenderer : public QgsMapLayerRenderer
           const double sy1h = hLine1.first().y();
           const double sy2h = hLine2.first().y();
           const QString label = gridLabel( mGridConfig.rowStart, row - 1 );
-          if ( mGridConfig.labelingPos == KadasGuideGridLayer::LabelsOutside && hLine1.first().x() - labelBoxSize > screenRect.left() )
+          if ( mGridConfig.labelingPos == LabelingPos::LabelsOutside && hLine1.first().x() - labelBoxSize > screenRect.left() )
             drawGridLabel( sx1 - 0.5 * labelBoxSize, 0.5 * ( sy1h + sy2h ), label, font, fontMetrics, bufferColor );
           else if ( sx1 < hLine1.last().x() - 2 * labelBoxSize )
             drawGridLabel( sx1 + 0.5 * labelBoxSize, 0.5 * ( sy1h + sy2h ), label, font, fontMetrics, bufferColor );
-          if ( mGridConfig.labelingPos == KadasGuideGridLayer::LabelsOutside && hLine1.last().x() + labelBoxSize < screenRect.right() )
+          if ( mGridConfig.labelingPos == LabelingPos::LabelsOutside && hLine1.last().x() + labelBoxSize < screenRect.right() )
             drawGridLabel( sx2 + 0.5 * labelBoxSize, 0.5 * ( sy1h + sy2h ), label, font, fontMetrics, bufferColor );
           else if ( sx2 > hLine1.first().x() + 2 * labelBoxSize )
             drawGridLabel( sx2 - 0.5 * labelBoxSize, 0.5 * ( sy1h + sy2h ), label, font, fontMetrics, bufferColor );
         }
 
-        if ( quadrantLabeling != KadasGuideGridLayer::DontLabelQuadrants )
+        if ( quadrantLabeling != QuadrantLabeling::DontLabelQuadrants )
         {
           p->save();
           p->setPen( QPen( mGridConfig.color, mGridConfig.lineWidth, Qt::DashLine ) );
           QPolygonF hLineMid;
-          if ( quadrantLabeling == KadasGuideGridLayer::LabelOneQuadrant )
+          if ( quadrantLabeling == QuadrantLabeling::LabelOneQuadrant )
           {
             hLineMid.append( 0.5 * ( hLine1.at( 0 ) + hLine2.at( 0 ) ) );
             hLineMid.append( 0.5 * ( hLine1.at( 1 ) + hLine2.at( 1 ) ) );
-            quadrantLabeling = KadasGuideGridLayer::DontLabelQuadrants;
+            quadrantLabeling = QuadrantLabeling::DontLabelQuadrants;
           }
           else
           {
@@ -367,7 +363,7 @@ QList<KadasPluginLayer::IdentifyResult> KadasGuideGridLayer::identify( const Qgs
   QMap<QString, QVariant> attrs;
 
   QString text = tr( "Cell %1, %2" ).arg( gridLabel( mGridConfig.rowStart, j ) ).arg( gridLabel( mGridConfig.colStart.at( 0 ), i ) );
-  if ( mGridConfig.quadrantLabeling != DontLabelQuadrants )
+  if ( mGridConfig.quadrantLabeling != QuadrantLabeling::DontLabelQuadrants )
   {
     bool left = pos.x() <= mGridConfig.gridRect.xMinimum() + ( i + 0.5 ) * colWidth;
     bool top = pos.y() >= mGridConfig.gridRect.yMaximum() - ( j + 0.5 ) * rowHeight;
@@ -561,7 +557,7 @@ void KadasGuideGridLayer::regenerate()
     const double cx = r.xMinimum() + ( col + 0.5 ) * dx;
     // Top
     {
-      const double cy = mGridConfig.labelingPos == LabelsOutside ? r.yMaximum() + 0.5 * dy : r.yMaximum() - 0.5 * dy;
+      const double cy = mGridConfig.labelingPos == LabelingPos::LabelsOutside ? r.yMaximum() + 0.5 * dy : r.yMaximum() - 0.5 * dy;
       auto *txt = new QgsAnnotationPointTextItem( label, QgsPointXY( cx, cy ) );
       txt->setFormat( textFmt );
       txt->setAlignment( Qt::AlignHCenter | Qt::AlignVCenter );
@@ -569,7 +565,7 @@ void KadasGuideGridLayer::regenerate()
     }
     // Bottom
     {
-      const double cy = mGridConfig.labelingPos == LabelsOutside ? r.yMinimum() - 0.5 * dy : r.yMinimum() + 0.5 * dy;
+      const double cy = mGridConfig.labelingPos == LabelingPos::LabelsOutside ? r.yMinimum() - 0.5 * dy : r.yMinimum() + 0.5 * dy;
       auto *txt = new QgsAnnotationPointTextItem( label, QgsPointXY( cx, cy ) );
       txt->setFormat( textFmt );
       txt->setAlignment( Qt::AlignHCenter | Qt::AlignVCenter );
@@ -584,7 +580,7 @@ void KadasGuideGridLayer::regenerate()
     const double cy = r.yMaximum() - ( row + 0.5 ) * dy;
     // Left
     {
-      const double cx = mGridConfig.labelingPos == LabelsOutside ? r.xMinimum() - 0.5 * dx : r.xMinimum() + 0.5 * dx;
+      const double cx = mGridConfig.labelingPos == LabelingPos::LabelsOutside ? r.xMinimum() - 0.5 * dx : r.xMinimum() + 0.5 * dx;
       auto *txt = new QgsAnnotationPointTextItem( label, QgsPointXY( cx, cy ) );
       txt->setFormat( textFmt );
       txt->setAlignment( Qt::AlignHCenter | Qt::AlignVCenter );
@@ -592,7 +588,7 @@ void KadasGuideGridLayer::regenerate()
     }
     // Right
     {
-      const double cx = mGridConfig.labelingPos == LabelsOutside ? r.xMaximum() + 0.5 * dx : r.xMaximum() - 0.5 * dx;
+      const double cx = mGridConfig.labelingPos == LabelingPos::LabelsOutside ? r.xMaximum() + 0.5 * dx : r.xMaximum() - 0.5 * dx;
       auto *txt = new QgsAnnotationPointTextItem( label, QgsPointXY( cx, cy ) );
       txt->setFormat( textFmt );
       txt->setAlignment( Qt::AlignHCenter | Qt::AlignVCenter );
@@ -601,10 +597,10 @@ void KadasGuideGridLayer::regenerate()
   }
 
   // --- Quadrant subgrid (mid-lines + ABCD micro-labels) ---
-  if ( mGridConfig.quadrantLabeling != DontLabelQuadrants )
+  if ( mGridConfig.quadrantLabeling != QuadrantLabeling::DontLabelQuadrants )
   {
-    const int qCols = mGridConfig.quadrantLabeling == LabelOneQuadrant ? 1 : mGridConfig.cols;
-    const int qRows = mGridConfig.quadrantLabeling == LabelOneQuadrant ? 1 : mGridConfig.rows;
+    const int qCols = mGridConfig.quadrantLabeling == QuadrantLabeling::LabelOneQuadrant ? 1 : mGridConfig.cols;
+    const int qRows = mGridConfig.quadrantLabeling == QuadrantLabeling::LabelOneQuadrant ? 1 : mGridConfig.rows;
 
     // Vertical mid-lines (one per quadrant column, splitting it horizontally in half)
     for ( int col = 0; col < qCols; ++col )

--- a/kadas/app/guidegrid/kadasguidegridlayer.cpp
+++ b/kadas/app/guidegrid/kadasguidegridlayer.cpp
@@ -38,8 +38,9 @@
 
 namespace
 {
-  QString gridLabel( QChar firstChar, int offset )
+  QString gridLabel( QString firstStart, int offset )
   {
+    QChar firstChar = firstStart.at( 0 );
     if ( firstChar >= '0' && firstChar <= '9' )
     {
       return QString::number( firstChar.digitValue() + offset );
@@ -140,7 +141,7 @@ class KadasGuideGridRenderer : public QgsMapLayerRenderer
         {
           const double sx1 = vLine1.first().x();
           const double sx2 = vLine2.first().x();
-          const QString label = gridLabel( mGridConfig.colChar, col - 1 );
+          const QString label = gridLabel( mGridConfig.colStart, col - 1 );
           if ( mGridConfig.labelingPos == KadasGuideGridLayer::LabelsOutside && vLine1.first().y() - labelBoxSize > screenRect.top() )
             drawGridLabel( 0.5 * ( sx1 + sx2 ), sy1 - 0.5 * labelBoxSize, label, font, fontMetrics, bufferColor );
           else if ( sy1 < vLine1.last().y() - 2 * labelBoxSize )
@@ -204,7 +205,7 @@ class KadasGuideGridRenderer : public QgsMapLayerRenderer
         {
           const double sy1h = hLine1.first().y();
           const double sy2h = hLine2.first().y();
-          const QString label = gridLabel( mGridConfig.rowChar, row - 1 );
+          const QString label = gridLabel( mGridConfig.rowStart, row - 1 );
           if ( mGridConfig.labelingPos == KadasGuideGridLayer::LabelsOutside && hLine1.first().x() - labelBoxSize > screenRect.left() )
             drawGridLabel( sx1 - 0.5 * labelBoxSize, 0.5 * ( sy1h + sy2h ), label, font, fontMetrics, bufferColor );
           else if ( sx1 < hLine1.last().x() - 2 * labelBoxSize )
@@ -355,7 +356,7 @@ QList<KadasPluginLayer::IdentifyResult> KadasGuideGridLayer::identify( const Qgs
   bbox->setExteriorRing( ring );
   QMap<QString, QVariant> attrs;
 
-  QString text = tr( "Cell %1, %2" ).arg( gridLabel( mGridConfig.rowChar, j ) ).arg( gridLabel( mGridConfig.colChar, i ) );
+  QString text = tr( "Cell %1, %2" ).arg( gridLabel( mGridConfig.rowStart, j ) ).arg( gridLabel( mGridConfig.colStart.at( 0 ), i ) );
   if ( mGridConfig.quadrantLabeling != DontLabelQuadrants )
   {
     bool left = pos.x() <= mGridConfig.gridRect.xMinimum() + ( i + 0.5 ) * colWidth;
@@ -393,10 +394,10 @@ bool KadasGuideGridLayer::readXml( const QDomNode &layer_node, QgsReadWriteConte
     mGridConfig.fontSize = customProperty( QStringLiteral( "kadas/guidegrid/fontSize" ) ).toInt();
     mGridConfig.color = QgsSymbolLayerUtils::decodeColor( customProperty( QStringLiteral( "kadas/guidegrid/color" ) ).toString() );
     mGridConfig.lineWidth = customProperty( QStringLiteral( "kadas/guidegrid/lineWidth" ), 1 ).toInt();
-    const QString rowChar = customProperty( QStringLiteral( "kadas/guidegrid/rowChar" ) ).toString();
-    const QString colChar = customProperty( QStringLiteral( "kadas/guidegrid/colChar" ) ).toString();
-    mGridConfig.rowChar = rowChar.isEmpty() ? QChar( 'A' ) : rowChar.at( 0 );
-    mGridConfig.colChar = colChar.isEmpty() ? QChar( '1' ) : colChar.at( 0 );
+    const QString rowStart = customProperty( QStringLiteral( "kadas/guidegrid/rowChar" ) ).toString();
+    const QString colStart = customProperty( QStringLiteral( "kadas/guidegrid/colChar" ) ).toString();
+    mGridConfig.rowStart = rowStart.isEmpty() ? QString( "A" ) : rowStart;
+    mGridConfig.colStart = colStart.isEmpty() ? QString( "1" ) : colStart;
     mGridConfig.labelingPos = static_cast<LabelingPos>( customProperty( QStringLiteral( "kadas/guidegrid/labelingPos" ) ).toInt() );
     mGridConfig.quadrantLabeling = static_cast<QuadrantLabeling>( customProperty( QStringLiteral( "kadas/guidegrid/quadrantLabeling" ) ).toInt() );
     regenerate();
@@ -421,8 +422,8 @@ bool KadasGuideGridLayer::readXml( const QDomNode &layer_node, QgsReadWriteConte
   mGridConfig.fontSize = cfgEl.attribute( "fontSize" ).toInt();
   mGridConfig.color = QgsSymbolLayerUtils::decodeColor( cfgEl.attribute( "color" ) );
   mGridConfig.lineWidth = cfgEl.attribute( "lineWidth", "1" ).toInt();
-  mGridConfig.rowChar = !cfgEl.attribute( "rowChar" ).isEmpty() ? cfgEl.attribute( "rowChar" ).at( 0 ) : 'A';
-  mGridConfig.colChar = !cfgEl.attribute( "colChar" ).isEmpty() ? cfgEl.attribute( "colChar" ).at( 0 ) : '1';
+  mGridConfig.rowStart = !cfgEl.attribute( "rowChar" ).isEmpty() ? cfgEl.attribute( "rowChar" ).at( 0 ) : 'A';
+  mGridConfig.colStart = !cfgEl.attribute( "colChar" ).isEmpty() ? cfgEl.attribute( "colChar" ).at( 0 ) : '1';
   mGridConfig.labelingPos = static_cast<LabelingPos>( cfgEl.attribute( "labelingPos" ).toInt() );
   mGridConfig.quadrantLabeling = static_cast<QuadrantLabeling>( cfgEl.attribute( "quadrantLabeling" ).toInt() );
 
@@ -457,8 +458,8 @@ void KadasGuideGridLayer::writeConfigToCustomProperties()
   setCustomProperty( QStringLiteral( "kadas/guidegrid/fontSize" ), mGridConfig.fontSize );
   setCustomProperty( QStringLiteral( "kadas/guidegrid/color" ), QgsSymbolLayerUtils::encodeColor( mGridConfig.color ) );
   setCustomProperty( QStringLiteral( "kadas/guidegrid/lineWidth" ), mGridConfig.lineWidth );
-  setCustomProperty( QStringLiteral( "kadas/guidegrid/rowChar" ), QString( mGridConfig.rowChar ) );
-  setCustomProperty( QStringLiteral( "kadas/guidegrid/colChar" ), QString( mGridConfig.colChar ) );
+  setCustomProperty( QStringLiteral( "kadas/guidegrid/rowChar" ), QString( mGridConfig.rowStart ) );
+  setCustomProperty( QStringLiteral( "kadas/guidegrid/colChar" ), QString( mGridConfig.colStart ) );
   setCustomProperty( QStringLiteral( "kadas/guidegrid/labelingPos" ), static_cast<int>( mGridConfig.labelingPos ) );
   setCustomProperty( QStringLiteral( "kadas/guidegrid/quadrantLabeling" ), static_cast<int>( mGridConfig.quadrantLabeling ) );
 }
@@ -546,7 +547,7 @@ void KadasGuideGridLayer::regenerate()
   // --- Column labels (top + bottom of the grid rect) ---
   for ( int col = 0; col < mGridConfig.cols; ++col )
   {
-    const QString label = gridLabel( mGridConfig.colChar, col );
+    const QString label = gridLabel( mGridConfig.colStart, col );
     const double cx = r.xMinimum() + ( col + 0.5 ) * dx;
     // Top
     {
@@ -569,7 +570,7 @@ void KadasGuideGridLayer::regenerate()
   // --- Row labels (left + right of the grid rect) ---
   for ( int row = 0; row < mGridConfig.rows; ++row )
   {
-    const QString label = gridLabel( mGridConfig.rowChar, row );
+    const QString label = gridLabel( mGridConfig.rowStart, row );
     const double cy = r.yMaximum() - ( row + 0.5 ) * dy;
     // Left
     {

--- a/kadas/app/guidegrid/kadasguidegridlayer.h
+++ b/kadas/app/guidegrid/kadasguidegridlayer.h
@@ -75,7 +75,7 @@ class KadasGuideGridLayer : public KadasAnnotationLayer
     const QColor &color() const { return mGridConfig.color; }
     int lineWidth() const { return mGridConfig.lineWidth; }
     int fontSize() const { return mGridConfig.fontSize; }
-    QPair<QChar, QChar> labelingMode() const { return qMakePair( mGridConfig.rowChar, mGridConfig.colChar ); }
+    QPair<QString, QString> labelingMode() const { return qMakePair( mGridConfig.rowStart, mGridConfig.colStart ); }
     LabelingPos labelingPos() const { return mGridConfig.labelingPos; }
     QuadrantLabeling labelQuadrants() const { return mGridConfig.quadrantLabeling; }
 
@@ -95,10 +95,10 @@ class KadasGuideGridLayer : public KadasAnnotationLayer
       mGridConfig.fontSize = fontSize;
       regenerate();
     }
-    void setLabelingMode( QChar rowChar, QChar colChar )
+    void setLabelingMode( QString rowStart, QString colStart )
     {
-      mGridConfig.rowChar = rowChar;
-      mGridConfig.colChar = colChar;
+      mGridConfig.rowStart = rowStart;
+      mGridConfig.colStart = colStart;
       regenerate();
     }
     void setLabelingPos( LabelingPos pos )
@@ -133,8 +133,8 @@ class KadasGuideGridLayer : public KadasAnnotationLayer
         int fontSize = 30;
         QColor color = Qt::red;
         int lineWidth = 1;
-        QChar rowChar = 'A';
-        QChar colChar = '1';
+        QString rowStart = QString( "A" );
+        QString colStart = QString( "1" );
         LabelingPos labelingPos = LabelsInside;
         QuadrantLabeling quadrantLabeling = DontLabelQuadrants;
     } mGridConfig;
@@ -199,7 +199,7 @@ class KadasGuideGridLayer : public KadasPluginLayer
     const QColor &color() const { return mGridConfig.color; }
     int lineWidth() const { return mGridConfig.lineWidth; }
     int fontSize() const { return mGridConfig.fontSize; }
-    QPair<QChar, QChar> labelingMode() const { return qMakePair( mGridConfig.rowChar, mGridConfig.colChar ); }
+    QPair<QString, QString> labelingMode() const { return qMakePair( mGridConfig.rowStart, mGridConfig.colStart ); }
     LabelingPos labelingPos() const { return mGridConfig.labelingPos; }
     QuadrantLabeling labelQuadrants() const { return mGridConfig.quadrantLabeling; }
 
@@ -207,10 +207,10 @@ class KadasGuideGridLayer : public KadasPluginLayer
     void setColor( const QColor &color ) { mGridConfig.color = color; }
     void setLineWidth( int lineWidth ) { mGridConfig.lineWidth = lineWidth; }
     void setFontSize( int fontSize ) { mGridConfig.fontSize = fontSize; }
-    void setLabelingMode( QChar rowChar, QChar colChar )
+    void setLabelingMode( QString rowStart, QString colStart )
     {
-      mGridConfig.rowChar = rowChar;
-      mGridConfig.colChar = colChar;
+      mGridConfig.rowStart = rowStart;
+      mGridConfig.colStart = colStart;
     }
     void setLabelingPos( LabelingPos pos ) { mGridConfig.labelingPos = pos; }
     void setLabelQuadrants( QuadrantLabeling labelQuadrants ) { mGridConfig.quadrantLabeling = labelQuadrants; }
@@ -232,8 +232,8 @@ class KadasGuideGridLayer : public KadasPluginLayer
         int fontSize = 30;
         QColor color = Qt::red;
         int lineWidth = 1;
-        QChar rowChar = 'A';
-        QChar colChar = '1';
+        QString rowStart = QString( "A" );
+        QString colStart = QString( "1" );
         LabelingPos labelingPos = LabelsInside;
         QuadrantLabeling quadrantLabeling = DontLabelQuadrants;
     } mGridConfig;

--- a/kadas/app/guidegrid/kadasguidegridlayer.h
+++ b/kadas/app/guidegrid/kadasguidegridlayer.h
@@ -46,6 +46,7 @@ struct GridConfig
     int lineWidth = 1;
     QString rowStart = QString( "A" );
     QString colStart = QString( "1" );
+    bool avoidRepeatingLetters = true;
     LabelingPos labelingPos = LabelingPos::LabelsInside;
     QuadrantLabeling quadrantLabeling = QuadrantLabeling::DontLabelQuadrants;
 };
@@ -94,6 +95,7 @@ class KadasGuideGridLayer : public KadasAnnotationLayer
     QPair<QString, QString> labelingMode() const { return qMakePair( mGridConfig.rowStart, mGridConfig.colStart ); }
     LabelingPos labelingPos() const { return mGridConfig.labelingPos; }
     QuadrantLabeling labelQuadrants() const { return mGridConfig.quadrantLabeling; }
+    bool avoidRepeatingLetters() const { return mGridConfig.avoidRepeatingLetters; }
 
   public slots:
     void setColor( const QColor &color )
@@ -125,6 +127,11 @@ class KadasGuideGridLayer : public KadasAnnotationLayer
     void setLabelQuadrants( QuadrantLabeling labelQuadrants )
     {
       mGridConfig.quadrantLabeling = labelQuadrants;
+      regenerate();
+    }
+    void setAvoidRepeatingLetters( bool avoidRepeatingLetters )
+    {
+      mGridConfig.avoidRepeatingLetters = avoidRepeatingLetters;
       regenerate();
     }
 
@@ -193,6 +200,7 @@ class KadasGuideGridLayer : public KadasPluginLayer
     QPair<QString, QString> labelingMode() const { return qMakePair( mGridConfig.rowStart, mGridConfig.colStart ); }
     LabelingPos labelingPos() const { return mGridConfig.labelingPos; }
     QuadrantLabeling labelQuadrants() const { return mGridConfig.quadrantLabeling; }
+    bool avoidRepeatingLetters() const { return mGridConfig.avoidRepeatingLetters; }
 
   public slots:
     void setColor( const QColor &color ) { mGridConfig.color = color; }
@@ -205,6 +213,7 @@ class KadasGuideGridLayer : public KadasPluginLayer
     }
     void setLabelingPos( LabelingPos pos ) { mGridConfig.labelingPos = pos; }
     void setLabelQuadrants( QuadrantLabeling labelQuadrants ) { mGridConfig.quadrantLabeling = labelQuadrants; }
+    void setAvoidRepeatingLetters( bool avoidRepeatingLetters ) { mGridConfig.avoidRepeatingLetters = avoidRepeatingLetters; }
 
   protected:
     bool readXml( const QDomNode &layer_node, QgsReadWriteContext &context ) override;

--- a/kadas/app/guidegrid/kadasguidegridlayer.h
+++ b/kadas/app/guidegrid/kadasguidegridlayer.h
@@ -22,6 +22,34 @@
 #include "kadas/app/kadasannotationlayer.h"
 #include "kadas/core/kadaspluginlayer.h"
 
+enum class LabelingPos
+{
+  LabelsInside,
+  LabelsOutside
+};
+enum class QuadrantLabeling
+{
+  DontLabelQuadrants,
+  LabelOneQuadrant,
+  LabelAllQuadrants
+};
+
+struct GridConfig
+{
+    QgsRectangle gridRect;
+    int cols = 0;
+    int rows = 0;
+    bool colSizeLocked = false;
+    bool rowSizeLocked = false;
+    int fontSize = 30;
+    QColor color = Qt::red;
+    int lineWidth = 1;
+    QString rowStart = QString( "A" );
+    QString colStart = QString( "1" );
+    LabelingPos labelingPos = LabelingPos::LabelsInside;
+    QuadrantLabeling quadrantLabeling = QuadrantLabeling::DontLabelQuadrants;
+};
+
 /**
  * Guide grid layer: draws a numbered/lettered rectangular grid over the map.
  *
@@ -43,18 +71,6 @@ class KadasGuideGridLayer : public KadasAnnotationLayer
 {
     Q_OBJECT
   public:
-    enum LabelingPos
-    {
-      LabelsInside,
-      LabelsOutside
-    };
-    enum QuadrantLabeling
-    {
-      DontLabelQuadrants,
-      LabelOneQuadrant,
-      LabelAllQuadrants
-    };
-
     static QString layerType() { return "guide_grid"; }
 
     explicit KadasGuideGridLayer( const QString &name );
@@ -123,21 +139,7 @@ class KadasGuideGridLayer : public KadasAnnotationLayer
     /// of this subclass and would strip any custom child element).
     void writeConfigToCustomProperties();
 
-    struct GridConfig
-    {
-        QgsRectangle gridRect;
-        int cols = 0;
-        int rows = 0;
-        bool colSizeLocked = false;
-        bool rowSizeLocked = false;
-        int fontSize = 30;
-        QColor color = Qt::red;
-        int lineWidth = 1;
-        QString rowStart = QString( "A" );
-        QString colStart = QString( "1" );
-        LabelingPos labelingPos = LabelsInside;
-        QuadrantLabeling quadrantLabeling = DontLabelQuadrants;
-    } mGridConfig;
+    GridConfig mGridConfig;
 
     /// Rebuild the layer's annotation items (lines + labels) from the current GridConfig.
     void regenerate() override;
@@ -169,17 +171,6 @@ class KadasGuideGridLayer : public KadasPluginLayer
 {
     Q_OBJECT
   public:
-    enum LabelingPos
-    {
-      LabelsInside,
-      LabelsOutside
-    };
-    enum QuadrantLabeling
-    {
-      DontLabelQuadrants,
-      LabelOneQuadrant,
-      LabelAllQuadrants
-    };
     static QString layerType() { return "guide_grid"; }
 
     KadasGuideGridLayer( const QString &name );
@@ -222,21 +213,7 @@ class KadasGuideGridLayer : public KadasPluginLayer
   private:
     class Renderer;
 
-    struct GridConfig
-    {
-        QgsRectangle gridRect;
-        int cols = 0;
-        int rows = 0;
-        bool colSizeLocked = false;
-        bool rowSizeLocked = false;
-        int fontSize = 30;
-        QColor color = Qt::red;
-        int lineWidth = 1;
-        QString rowStart = QString( "A" );
-        QString colStart = QString( "1" );
-        LabelingPos labelingPos = LabelsInside;
-        QuadrantLabeling quadrantLabeling = DontLabelQuadrants;
-    } mGridConfig;
+    GridConfig mGridConfig;
 };
 
 

--- a/kadas/app/guidegrid/kadasguidegridutils.cpp
+++ b/kadas/app/guidegrid/kadasguidegridutils.cpp
@@ -1,0 +1,65 @@
+/***************************************************************************
+    kadasguidegridutils.cpp
+    ------------------------
+    copyright            : (C) 2026 by OPENGIS.ch
+    email                : info@opengis.ch
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include <algorithm>
+
+#include "guidegrid/kadasguidegridutils.h"
+
+QString KadasGuideGridUtils::gridLabel( const QString &firstStart, int offset, bool avoidRepeatingLetters )
+{
+  bool isInt = false;
+  int startNumber = firstStart.toInt( &isInt );
+  if ( isInt )
+  {
+    return QString::number( startNumber + offset );
+  }
+
+  // Convert to decimal base
+  int startOffset = 0;
+  for ( int i = 0; i < firstStart.length(); ++i )
+  {
+    QChar c = firstStart.at( i );
+    startOffset = startOffset * 26 + ( c.toLatin1() - 'A' + 1 );
+  }
+
+  int skipped = 0;
+  if ( avoidRepeatingLetters )
+  {
+    for ( int i = 0; i <= offset; i++ )
+    {
+      QString lbl = KadasGuideGridUtils::gridLabel( firstStart, i );
+      QChar firstChar = lbl.at( 0 );
+      bool isRepeating = std::all_of( lbl.begin(), lbl.end(), [firstChar]( QChar c ) { return c == firstChar; } );
+
+      if ( lbl.length() != 1 && isRepeating )
+      {
+        skipped++;
+      }
+    }
+  }
+
+  offset += startOffset + skipped;
+
+  QString label;
+  do
+  {
+    offset -= 1;
+    int res = offset % 26;
+    label.prepend( QChar( 'A' + res ) );
+    offset /= 26;
+  } while ( offset > 0 );
+  return label;
+}

--- a/kadas/app/guidegrid/kadasguidegridutils.h
+++ b/kadas/app/guidegrid/kadasguidegridutils.h
@@ -1,0 +1,31 @@
+/***************************************************************************
+    kadasguidegridutils.h
+    ----------------------
+    copyright            : (C) 2026 by OPENGIS.ch
+    email                : info@opengis.ch
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef KADASGUIDEGRIDUTILS_H
+#define KADASGUIDEGRIDUTILS_H
+
+#include <QString>
+
+/**
+ * Helpers for guide grid labeling, used by both KadasGuideGridLayer and KadasGuideGridRenderer.
+ */
+class KadasGuideGridUtils
+{
+  public:
+    static QString gridLabel( const QString &firstStart, int offset, bool avoidRepeatingLetters = false );
+};
+
+#endif // KADASGUIDEGRIDUTILS_H

--- a/kadas/app/guidegrid/kadasguidegridwidgetbase.ui
+++ b/kadas/app/guidegrid/kadasguidegridwidgetbase.ui
@@ -314,6 +314,9 @@
           </property>
           <item>
            <widget class="QComboBox" name="comboBoxRowLabels">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Starting label for coordinates&lt;/p&gt;&lt;p&gt;Example 'A', 'AA' or 'BA' &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
             <property name="editable">
              <bool>true</bool>
             </property>
@@ -329,6 +332,9 @@
           </item>
           <item>
            <widget class="QComboBox" name="comboBoxColLabels">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Starting label for coordinates&lt;/p&gt;&lt;p&gt;Example '1' , '20' or '100' &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
             <property name="editable">
              <bool>true</bool>
             </property>

--- a/kadas/app/guidegrid/kadasguidegridwidgetbase.ui
+++ b/kadas/app/guidegrid/kadasguidegridwidgetbase.ui
@@ -313,7 +313,11 @@
            <number>0</number>
           </property>
           <item>
-           <widget class="QComboBox" name="comboBoxRowLabels"/>
+           <widget class="QComboBox" name="comboBoxRowLabels">
+            <property name="editable">
+             <bool>true</bool>
+            </property>
+           </widget>
           </item>
           <item>
            <widget class="QToolButton" name="toolButtonSwitchLabels">
@@ -324,7 +328,11 @@
            </widget>
           </item>
           <item>
-           <widget class="QComboBox" name="comboBoxColLabels"/>
+           <widget class="QComboBox" name="comboBoxColLabels">
+            <property name="editable">
+             <bool>true</bool>
+            </property>
+           </widget>
           </item>
          </layout>
         </item>

--- a/kadas/app/guidegrid/kadasguidegridwidgetbase.ui
+++ b/kadas/app/guidegrid/kadasguidegridwidgetbase.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>381</width>
-    <height>400</height>
+    <height>392</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayoutMain">
@@ -83,7 +83,7 @@
         <item>
          <widget class="QToolButton" name="toolButtonPickTopLeft">
           <property name="icon">
-           <iconset>
+           <iconset resource="../../resources/resources.qrc">
             <normaloff>:/kadas/icons/pick</normaloff>:/kadas/icons/pick</iconset>
           </property>
          </widget>
@@ -112,7 +112,7 @@
         <item>
          <widget class="QToolButton" name="toolButtonPickBottomRight">
           <property name="icon">
-           <iconset>
+           <iconset resource="../../resources/resources.qrc">
             <normaloff>:/kadas/icons/pick</normaloff>:/kadas/icons/pick</iconset>
           </property>
          </widget>
@@ -197,7 +197,7 @@
         <item>
          <widget class="QToolButton" name="toolButtonLockWidth">
           <property name="icon">
-           <iconset>
+           <iconset resource="../../resources/resources.qrc">
             <normaloff>:/kadas/icons/unlocked</normaloff>:/kadas/icons/unlocked</iconset>
           </property>
           <property name="checkable">
@@ -231,7 +231,7 @@
         <item>
          <widget class="QToolButton" name="toolButtonLockHeight">
           <property name="icon">
-           <iconset>
+           <iconset resource="../../resources/resources.qrc">
             <normaloff>:/kadas/icons/unlocked</normaloff>:/kadas/icons/unlocked</iconset>
           </property>
           <property name="checkable">
@@ -325,7 +325,7 @@
           <item>
            <widget class="QToolButton" name="toolButtonSwitchLabels">
             <property name="icon">
-             <iconset>
+             <iconset resource="../../resources/resources.qrc">
               <normaloff>:/kadas/icons/switch</normaloff>:/kadas/icons/switch</iconset>
             </property>
            </widget>
@@ -356,6 +356,23 @@
          </layout>
         </item>
        </layout>
+      </item>
+      <item row="8" column="1">
+       <widget class="QCheckBox" name="checkBoxAvoidRepeatingLetters">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="0">
+       <widget class="QLabel" name="label">
+        <property name="toolTip">
+         <string>Example: &quot;AA&quot;, &quot;BB&quot; &quot;CCC&quot;</string>
+        </property>
+        <property name="text">
+         <string>Avoid repeating letters</string>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>

--- a/kadas/app/guidegrid/kadasmaptoolguidegrid.cpp
+++ b/kadas/app/guidegrid/kadasmaptoolguidegrid.cpp
@@ -200,6 +200,7 @@ KadasGuideGridWidget::KadasGuideGridWidget( QgsMapCanvas *canvas, QgsLayerTreeVi
   connect( ui.toolButtonSwitchLabels, &QToolButton::clicked, this, &KadasGuideGridWidget::switchLabels );
   connect( ui.comboBoxLabelPos, qOverload<int>( &QComboBox::currentIndexChanged ), this, &KadasGuideGridWidget::updateLabeling );
   connect( ui.comboBoxQuadrants, qOverload<int>( &QComboBox::currentIndexChanged ), this, &KadasGuideGridWidget::updateLabeling );
+  connect( ui.checkBoxAvoidRepeatingLetters, &QCheckBox::toggled, this, &KadasGuideGridWidget::updateLabeling );
 
   connect( mLayerSelectionWidget, &KadasLayerSelectionWidget::selectedLayerChanged, this, &KadasGuideGridWidget::setCurrentLayer );
 
@@ -279,6 +280,9 @@ void KadasGuideGridWidget::setCurrentLayer( QgsMapLayer *layer )
   ui.comboBoxQuadrants->blockSignals( true );
   ui.comboBoxQuadrants->setCurrentIndex( ui.comboBoxQuadrants->findData( static_cast<int>( mCurrentLayer->labelQuadrants() ) ) );
   ui.comboBoxQuadrants->blockSignals( false );
+  ui.checkBoxAvoidRepeatingLetters->blockSignals( true );
+  ui.checkBoxAvoidRepeatingLetters->setChecked( mCurrentLayer->avoidRepeatingLetters() );
+  ui.checkBoxAvoidRepeatingLetters->blockSignals( false );
   updateIntervals();
   ui.widgetLayerSetup->setEnabled( true );
 }
@@ -489,5 +493,6 @@ void KadasGuideGridWidget::updateLabeling()
   mCurrentLayer->setLabelingMode( ui.comboBoxRowLabels->currentText().toUpper(), ui.comboBoxColLabels->currentText().toUpper() );
   mCurrentLayer->setLabelingPos( static_cast<LabelingPos>( ui.comboBoxLabelPos->currentData().toInt() ) );
   mCurrentLayer->setLabelQuadrants( static_cast<QuadrantLabeling>( ui.comboBoxQuadrants->currentData().toInt() ) );
+  mCurrentLayer->setAvoidRepeatingLetters( ui.checkBoxAvoidRepeatingLetters->isChecked() );
   mCurrentLayer->triggerRepaint();
 }

--- a/kadas/app/guidegrid/kadasmaptoolguidegrid.cpp
+++ b/kadas/app/guidegrid/kadasmaptoolguidegrid.cpp
@@ -259,7 +259,7 @@ void KadasGuideGridWidget::setCurrentLayer( QgsMapLayer *layer )
   ui.spinBoxLineWidth->setValue( mCurrentLayer->lineWidth() );
   ui.spinBoxLineWidth->blockSignals( false );
   ui.spinBoxFontSize->setValue( mCurrentLayer->fontSize() );
-  QPair<QChar, QChar> labelingMode = mCurrentLayer->labelingMode();
+  QPair<QString, QString> labelingMode = mCurrentLayer->labelingMode();
   ui.comboBoxRowLabels->blockSignals( true );
   ui.comboBoxRowLabels->setCurrentText( QString( labelingMode.first ) );
   ui.comboBoxRowLabels->blockSignals( false );
@@ -479,7 +479,7 @@ void KadasGuideGridWidget::updateLabeling()
   {
     return;
   }
-  mCurrentLayer->setLabelingMode( ui.comboBoxRowLabels->currentText().front(), ui.comboBoxColLabels->currentText().front() );
+  mCurrentLayer->setLabelingMode( ui.comboBoxRowLabels->currentText(), ui.comboBoxColLabels->currentText() );
   mCurrentLayer->setLabelingPos( static_cast<KadasGuideGridLayer::LabelingPos>( ui.comboBoxLabelPos->currentData().toInt() ) );
   mCurrentLayer->setLabelQuadrants( static_cast<KadasGuideGridLayer::QuadrantLabeling>( ui.comboBoxQuadrants->currentData().toInt() ) );
   mCurrentLayer->triggerRepaint();

--- a/kadas/app/guidegrid/kadasmaptoolguidegrid.cpp
+++ b/kadas/app/guidegrid/kadasmaptoolguidegrid.cpp
@@ -188,8 +188,8 @@ KadasGuideGridWidget::KadasGuideGridWidget( QgsMapCanvas *canvas, QgsLayerTreeVi
   connect( ui.toolButtonColor, &QgsColorButton::colorChanged, this, &KadasGuideGridWidget::updateColor );
   connect( ui.spinBoxLineWidth, qOverload<int>( &QSpinBox::valueChanged ), this, &KadasGuideGridWidget::updateLineWidth );
   connect( ui.spinBoxFontSize, qOverload<int>( &QSpinBox::valueChanged ), this, &KadasGuideGridWidget::updateFontSize );
-  connect( ui.comboBoxRowLabels, qOverload<int>( &QComboBox::currentIndexChanged ), this, &KadasGuideGridWidget::updateLabeling );
-  connect( ui.comboBoxColLabels, qOverload<int>( &QComboBox::currentIndexChanged ), this, &KadasGuideGridWidget::updateLabeling );
+  connect( ui.comboBoxRowLabels, qOverload<const QString &>( &QComboBox::currentTextChanged ), this, &KadasGuideGridWidget::updateLabeling );
+  connect( ui.comboBoxColLabels, qOverload<const QString &>( &QComboBox::currentTextChanged ), this, &KadasGuideGridWidget::updateLabeling );
   connect( ui.toolButtonSwitchLabels, &QToolButton::clicked, this, &KadasGuideGridWidget::switchLabels );
   connect( ui.comboBoxLabelPos, qOverload<int>( &QComboBox::currentIndexChanged ), this, &KadasGuideGridWidget::updateLabeling );
   connect( ui.comboBoxQuadrants, qOverload<int>( &QComboBox::currentIndexChanged ), this, &KadasGuideGridWidget::updateLabeling );
@@ -479,7 +479,7 @@ void KadasGuideGridWidget::updateLabeling()
   {
     return;
   }
-  mCurrentLayer->setLabelingMode( ui.comboBoxRowLabels->currentText(), ui.comboBoxColLabels->currentText() );
+  mCurrentLayer->setLabelingMode( ui.comboBoxRowLabels->currentText().toUpper(), ui.comboBoxColLabels->currentText().toUpper() );
   mCurrentLayer->setLabelingPos( static_cast<KadasGuideGridLayer::LabelingPos>( ui.comboBoxLabelPos->currentData().toInt() ) );
   mCurrentLayer->setLabelQuadrants( static_cast<KadasGuideGridLayer::QuadrantLabeling>( ui.comboBoxQuadrants->currentData().toInt() ) );
   mCurrentLayer->triggerRepaint();

--- a/kadas/app/guidegrid/kadasmaptoolguidegrid.cpp
+++ b/kadas/app/guidegrid/kadasmaptoolguidegrid.cpp
@@ -114,6 +114,13 @@ KadasGuideGridWidget::KadasGuideGridWidget( QgsMapCanvas *canvas, QgsLayerTreeVi
   ui.setupUi( base );
   addRow( base );
 
+  // Match either a number xor a letters, but not both (e.g not abc1234) .
+  QRegularExpression rx( "^(?:\\d+|[A-Za-z]+)$" );
+
+  QValidator *validatorNumberXorLetter = new QRegularExpressionValidator( rx, this );
+  ui.comboBoxRowLabels->setValidator( validatorNumberXorLetter );
+  ui.comboBoxColLabels->setValidator( validatorNumberXorLetter );
+
   for ( int c = 'A'; c <= 'Z'; ++c )
   {
     ui.comboBoxRowLabels->addItem( QChar( c ) );

--- a/kadas/app/guidegrid/kadasmaptoolguidegrid.cpp
+++ b/kadas/app/guidegrid/kadasmaptoolguidegrid.cpp
@@ -129,12 +129,12 @@ KadasGuideGridWidget::KadasGuideGridWidget( QgsMapCanvas *canvas, QgsLayerTreeVi
   {
     ui.comboBoxColLabels->addItem( QChar( c ) );
   }
-  ui.comboBoxLabelPos->addItem( tr( "Inside" ), KadasGuideGridLayer::LabelsInside );
-  ui.comboBoxLabelPos->addItem( tr( "Outside" ), KadasGuideGridLayer::LabelsOutside );
+  ui.comboBoxLabelPos->addItem( tr( "Inside" ), static_cast<int>( LabelingPos::LabelsInside ) );
+  ui.comboBoxLabelPos->addItem( tr( "Outside" ), static_cast<int>( LabelingPos::LabelsOutside ) );
 
-  ui.comboBoxQuadrants->addItem( tr( "Don't label quadrants" ), KadasGuideGridLayer::DontLabelQuadrants );
-  ui.comboBoxQuadrants->addItem( tr( "Label one quadrant" ), KadasGuideGridLayer::LabelOneQuadrant );
-  ui.comboBoxQuadrants->addItem( tr( "Label all quadrants" ), KadasGuideGridLayer::LabelAllQuadrants );
+  ui.comboBoxQuadrants->addItem( tr( "Don't label quadrants" ), static_cast<int>( QuadrantLabeling::DontLabelQuadrants ) );
+  ui.comboBoxQuadrants->addItem( tr( "Label one quadrant" ), static_cast<int>( QuadrantLabeling::LabelOneQuadrant ) );
+  ui.comboBoxQuadrants->addItem( tr( "Label all quadrants" ), static_cast<int>( QuadrantLabeling::LabelAllQuadrants ) );
 
   // The label-position combos carry long captions; let them shrink and elide
   // the current text instead of forcing the whole panel to the widest item
@@ -274,10 +274,10 @@ void KadasGuideGridWidget::setCurrentLayer( QgsMapLayer *layer )
   ui.comboBoxColLabels->setCurrentText( QString( labelingMode.second ) );
   ui.comboBoxColLabels->blockSignals( false );
   ui.comboBoxLabelPos->blockSignals( true );
-  ui.comboBoxLabelPos->setCurrentIndex( ui.comboBoxLabelPos->findData( mCurrentLayer->labelingPos() ) );
+  ui.comboBoxLabelPos->setCurrentIndex( ui.comboBoxLabelPos->findData( static_cast<int>( mCurrentLayer->labelingPos() ) ) );
   ui.comboBoxLabelPos->blockSignals( false );
   ui.comboBoxQuadrants->blockSignals( true );
-  ui.comboBoxQuadrants->setCurrentIndex( ui.comboBoxQuadrants->findData( mCurrentLayer->labelQuadrants() ) );
+  ui.comboBoxQuadrants->setCurrentIndex( ui.comboBoxQuadrants->findData( static_cast<int>( mCurrentLayer->labelQuadrants() ) ) );
   ui.comboBoxQuadrants->blockSignals( false );
   updateIntervals();
   ui.widgetLayerSetup->setEnabled( true );
@@ -487,7 +487,7 @@ void KadasGuideGridWidget::updateLabeling()
     return;
   }
   mCurrentLayer->setLabelingMode( ui.comboBoxRowLabels->currentText().toUpper(), ui.comboBoxColLabels->currentText().toUpper() );
-  mCurrentLayer->setLabelingPos( static_cast<KadasGuideGridLayer::LabelingPos>( ui.comboBoxLabelPos->currentData().toInt() ) );
-  mCurrentLayer->setLabelQuadrants( static_cast<KadasGuideGridLayer::QuadrantLabeling>( ui.comboBoxQuadrants->currentData().toInt() ) );
+  mCurrentLayer->setLabelingPos( static_cast<LabelingPos>( ui.comboBoxLabelPos->currentData().toInt() ) );
+  mCurrentLayer->setLabelQuadrants( static_cast<QuadrantLabeling>( ui.comboBoxQuadrants->currentData().toInt() ) );
   mCurrentLayer->triggerRepaint();
 }


### PR DESCRIPTION
This PR allows to type manually the start offset  of label grid coordinate eg: 'AA', 'BA' 
Previously offsetting the start label was possible but only limited to the first 26 letters or 10 first digits


A checkbox avoid repeating letters